### PR TITLE
Integrate overlay renderer into MarkRight editor

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,12 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Run Extension",
+      "type": "extensionHost",
+      "request": "launch",
+      "args": ["--extensionDevelopmentPath=${workspaceFolder}"],
+      "outFiles": ["${workspaceFolder}/dist/**/*.js"]
+    }
+  ]
+}

--- a/docs/issue-3-dev-brief.md
+++ b/docs/issue-3-dev-brief.md
@@ -1,0 +1,119 @@
+# Developer Brief: Issue #3 - WYSIWYG Markdown Editor for VSCode
+
+## Context
+
+This issue outlines a comprehensive feature specification for implementing a WYSIWYG (What You See Is What You Get) Markdown Editor as a VSCode extension. The goal is to create an advanced editing experience that combines the flexibility of markdown source editing with rich visual preview capabilities, including selective editing modes, LaTeX math rendering, diagram support, and extensive customization options.
+
+The specification is organized into 25 detailed features across core rendering, UI/UX, editor behavior, advanced features, configuration, and technical requirements. It's designed as a foundation for a powerful note-taking and document editing tool within VSCode.
+
+## Requirements
+
+- **Core Rendering**: Implement selective editing mode where users can click on rendered content to edit the underlying markdown source
+- **Typography System**: Configurable heading hierarchy with custom line heights and spacing
+- **Math Support**: LaTeX formula rendering with live preview editing (KaTeX/MathJax options)
+- **Table Support**: Visual table editing with cell navigation, resizing, and advanced features
+- **Diagram Integration**: Support for Mermaid, GraphViz, and PlantUML with live preview
+- **UI Components**: Floating table of contents, collapsible frontmatter, focus modes
+- **Performance**: Virtual scrolling, incremental rendering, and caching for large documents
+- **Customization**: CSS-based theming system with workspace and global styles
+- **Plugin Architecture**: Extensible system for third-party plugins
+
+## Acceptance Criteria
+
+- **Selective Editing**: Smooth transitions between rendered and source views with cursor preservation
+- **Typography**: Configurable heading scales (H1: 2.5em, H2: 2.2em, etc.) with smart spacing
+- **Math Rendering**: Inline `$...$` and block `$$...$$` formulas with click-to-edit functionality
+- **Table Editing**: Visual cell editing, Tab navigation, column resizing, multi-line support
+- **Diagram Support**: Live preview with side-by-side editing and export options
+- **Performance**: Handle documents >10k lines with virtual scrolling and debounced updates
+- **Customization**: CSS variables system with live reload and cascade priority
+- **Plugin System**: Extension API with safe mode and settings management
+
+## Tasks/Milestones
+
+### Phase 1: Foundation (Critical Path)
+
+1. **Issue #4**: Core Editor Architecture & Selective Editing Mode (3-4 weeks)
+
+   - Implement selective editing mode with smooth transitions
+   - Smart context detection for blocks vs inline elements
+   - Syntax dimming system
+
+2. **Issue #5**: Typography System & Rendering Engine (2-3 weeks)
+   - Configurable heading hierarchy and line heights
+   - CSS architecture with variables and custom file support
+   - Live reload for style changes
+
+### Phase 2: Content Enhancement (High Priority)
+
+1. **Issue #6**: Enhanced List and Table Support (2 weeks)
+
+   - Visual list hierarchy with different bullet styles
+   - Interactive features (drag/drop, checkbox toggles)
+   - Basic table editing with cell navigation
+
+2. **Issue #7**: LaTeX Math & Advanced Tables (3 weeks)
+   - LaTeX formula rendering with live preview editing
+   - Advanced table features (multi-line cells, column resize)
+   - Export options for tables
+
+### Phase 3: UI/UX Enhancement (Medium Priority)
+
+1. **Issue #8**: Navigation & UI Components (2-3 weeks)
+
+   - Floating Table of Contents with level controls
+   - Frontmatter collapse/expand functionality
+   - Focus modes (typewriter, focus, zen, reading)
+
+2. **Issue #9**: Diagram Support & Media Handling (2-3 weeks)
+   - Mermaid, GraphViz, PlantUML rendering
+   - Enhanced image handling (resize, preview, lazy loading)
+   - Link preview and footnote hover features
+
+### Phase 4: Advanced Features (Low Priority)
+
+1. **Issue #10**: Smart Editing & Auto-completion (2 weeks)
+
+   - Auto-completion for wiki-links, tags, emoji
+   - Smart editing assists and table assistance
+   - Fuzzy matching for suggestions
+
+2. **Issue #11**: Performance & Configuration (2-3 weeks)
+   - Virtual scrolling and incremental rendering
+   - Comprehensive settings system with profiles
+   - Plugin architecture foundation
+
+## Risks
+
+- **Complexity of Selective Editing**: Mapping cursor positions between rendered and source views may require significant DOM manipulation
+- **Performance Bottlenecks**: Large documents with complex content (diagrams, math) could impact rendering performance
+- **Library Dependencies**: Integration of KaTeX/MathJax, Mermaid, etc. may introduce compatibility issues
+- **CSS Customization**: User-provided CSS could conflict with extension styles or cause rendering issues
+- **Plugin Architecture**: Designing a secure and extensible plugin system while maintaining performance
+
+## Open Questions
+
+- Which math renderer to prioritize: KaTeX (faster) or MathJax (more comprehensive)?
+- How to handle cursor position mapping in complex nested structures?
+- What level of plugin API surface to expose initially?
+- How to implement virtual scrolling without breaking existing VSCode editor features?
+- Should diagram editing be inline or in separate panels?
+
+## References
+
+- **Primary Spec**: [GitHub Issue #3](https://github.com/PabloLION/MarkLeft/issues/3) - Complete feature specification
+- **Related Issues**:
+  - Issue #4: Core Editor Architecture
+  - Issue #5: Typography System
+  - Issue #6: Enhanced Lists & Tables
+  - Issue #7: LaTeX Math & Advanced Tables
+- **VSCode Extension APIs**: Documentation for custom editors, webview panels, and text document content providers
+- **Libraries**: KaTeX, MathJax, Mermaid.js, GraphViz integration guides
+
+## Implementation Notes
+
+- Use VSCode's Custom Editor API for the WYSIWYG experience
+- Implement webview-based rendering for rich content display
+- Leverage CSS custom properties for theming flexibility
+- Consider web workers for heavy processing (math rendering, diagram generation)
+- Plan for incremental adoption: start with core selective editing, add features iteratively

--- a/media/editor.css
+++ b/media/editor.css
@@ -104,6 +104,15 @@ body {
   tab-size: 2;
 }
 
+#markdown-editor.overlay-active {
+  color: transparent;
+  caret-color: var(--text-primary);
+}
+
+#markdown-editor.overlay-active::selection {
+  background: rgba(0, 122, 204, 0.35);
+}
+
 #markdown-editor::placeholder {
   color: var(--text-secondary);
 }

--- a/media/editor.js
+++ b/media/editor.js
@@ -1,364 +1,923 @@
-(function() {
-    'use strict';
+(function () {
+  "use strict";
 
-    // Get the VS Code API
-    const vscode = acquireVsCodeApi();
+  // Get the VS Code API
+  const vscode = acquireVsCodeApi();
 
-    // DOM elements
-    const editor = document.getElementById('markdown-editor');
-    const preview = document.getElementById('markdown-preview');
-    const previewPane = document.getElementById('preview-pane');
-    const editorPane = document.getElementById('editor-pane');
+  // DOM elements
+  const editor = document.getElementById("markdown-editor");
+  const preview = document.getElementById("markdown-preview");
+  const previewPane = document.getElementById("preview-pane");
+  const editorPane = document.getElementById("editor-pane");
+  const overlayContainer = document.getElementById("overlay-container");
 
-    // Toolbar buttons
-    const togglePreviewBtn = document.getElementById('toggle-preview');
-    const insertTableBtn = document.getElementById('insert-table');
-    const insertLinkBtn = document.getElementById('insert-link');
-    const focusModeBtn = document.getElementById('focus-mode');
-    const insertMathBtn = document.getElementById('insert-math');
-    const insertDiagramBtn = document.getElementById('insert-diagram');
+  // Toolbar buttons
+  const togglePreviewBtn = document.getElementById("toggle-preview");
+  const insertTableBtn = document.getElementById("insert-table");
+  const insertLinkBtn = document.getElementById("insert-link");
+  const focusModeBtn = document.getElementById("focus-mode");
+  const insertMathBtn = document.getElementById("insert-math");
+  const insertDiagramBtn = document.getElementById("insert-diagram");
 
-    // State
-    let currentText = '';
-    let previewVisible = true;
-    let focusMode = 'off';
+  // State
+  let currentText = "";
+  let previewVisible = true;
+  let focusMode = "off";
+  let editorLineHeight = 20;
+  let editorPaddingLeft = 0;
 
-    // Initialize
-    init();
+  // Selective editing state
+  let editRegions = new Map(); // Maps region IDs to {start, end, type, element}
+  let nextRegionId = 1;
+  let isSelectiveEditingEnabled = true;
 
-    function init() {
-        setupEventListeners();
-        setupMermaid();
-        requestInitialContent();
+  // Initialize
+  init();
+
+  function init() {
+    setupEventListeners();
+    setupMermaid();
+    measureEditorMetrics();
+    enableSelectiveEditing(); // Enable selective editing by default
+    requestInitialContent();
+  }
+
+  function setupEventListeners() {
+    // Editor events
+    editor.addEventListener("input", onEditorInput);
+    editor.addEventListener("scroll", onEditorScroll);
+    editor.addEventListener("keydown", onEditorKeyDown);
+    editor.addEventListener("keyup", updateOverlayVisibilityForCaret);
+    editor.addEventListener("click", updateOverlayVisibilityForCaret);
+    editor.addEventListener("select", updateOverlayVisibilityForCaret);
+    editor.addEventListener("focus", updateOverlayVisibilityForCaret);
+    editor.addEventListener("blur", () => setOverlayVisibility(true));
+
+    // Toolbar events
+    togglePreviewBtn.addEventListener("click", togglePreview);
+    insertTableBtn.addEventListener("click", insertTable);
+    insertLinkBtn.addEventListener("click", insertWikiLink);
+    focusModeBtn.addEventListener("click", toggleFocusMode);
+    insertMathBtn.addEventListener("click", insertMath);
+    insertDiagramBtn.addEventListener("click", insertDiagram);
+
+    // VS Code messages
+    window.addEventListener("message", onVSCodeMessage);
+
+    // Preview click events
+    preview.addEventListener("click", onPreviewClick);
+
+    window.addEventListener("resize", onWindowResize);
+  }
+
+  function setupMermaid() {
+    // Initialize Mermaid for diagram rendering
+    if (typeof mermaid !== "undefined") {
+      mermaid.initialize({
+        startOnLoad: false,
+        theme: "dark",
+        themeVariables: {
+          primaryColor: "#007acc",
+          primaryTextColor: "#cccccc",
+          primaryBorderColor: "#3e3e42",
+          lineColor: "#969696",
+          sectionBkgColor: "#252526",
+          altSectionBkgColor: "#1e1e1e",
+          gridColor: "#3e3e42",
+          secondaryColor: "#2d2d30",
+          tertiaryColor: "#1e1e1e",
+        },
+      });
+    }
+  }
+
+  function onEditorInput() {
+    const text = editor.value;
+    currentText = text;
+
+    // Send update to VS Code
+    vscode.postMessage({
+      type: "edit",
+      text: text,
+    });
+
+    // Update preview
+    if (previewVisible) {
+      updatePreview(text);
     }
 
-    function setupEventListeners() {
-        // Editor events
-        editor.addEventListener('input', onEditorInput);
-        editor.addEventListener('scroll', onEditorScroll);
-        editor.addEventListener('keydown', onEditorKeyDown);
+    measureEditorMetrics();
+    updateOverlayVisibilityForCaret();
+  }
 
-        // Toolbar events
-        togglePreviewBtn.addEventListener('click', togglePreview);
-        insertTableBtn.addEventListener('click', insertTable);
-        insertLinkBtn.addEventListener('click', insertWikiLink);
-        focusModeBtn.addEventListener('click', toggleFocusMode);
-        insertMathBtn.addEventListener('click', insertMath);
-        insertDiagramBtn.addEventListener('click', insertDiagram);
-
-        // VS Code messages
-        window.addEventListener('message', onVSCodeMessage);
-
-        // Preview click events
-        preview.addEventListener('click', onPreviewClick);
+  function onEditorScroll() {
+    // Sync scroll between editor and preview
+    if (previewVisible) {
+      const scrollPercent =
+        editor.scrollTop / (editor.scrollHeight - editor.clientHeight);
+      preview.scrollTop =
+        scrollPercent * (preview.scrollHeight - preview.clientHeight);
     }
 
-    function setupMermaid() {
-        // Initialize Mermaid for diagram rendering
-        if (typeof mermaid !== 'undefined') {
-            mermaid.initialize({
-                startOnLoad: false,
-                theme: 'dark',
-                themeVariables: {
-                    primaryColor: '#007acc',
-                    primaryTextColor: '#cccccc',
-                    primaryBorderColor: '#3e3e42',
-                    lineColor: '#969696',
-                    sectionBkgColor: '#252526',
-                    altSectionBkgColor: '#1e1e1e',
-                    gridColor: '#3e3e42',
-                    secondaryColor: '#2d2d30',
-                    tertiaryColor: '#1e1e1e'
-                }
-            });
+    positionOverlays();
+  }
+
+  function onEditorKeyDown(event) {
+    // Handle special key combinations
+    if (event.ctrlKey || event.metaKey) {
+      switch (event.key) {
+        case "b":
+          event.preventDefault();
+          insertFormatting("**", "**", "bold text");
+          break;
+        case "i":
+          event.preventDefault();
+          insertFormatting("*", "*", "italic text");
+          break;
+        case "k":
+          event.preventDefault();
+          insertWikiLink();
+          break;
+      }
+    }
+
+    // Handle Tab key for indentation
+    if (event.key === "Tab") {
+      event.preventDefault();
+      const start = editor.selectionStart;
+      const end = editor.selectionEnd;
+
+      if (event.shiftKey) {
+        // Shift+Tab: Remove indentation
+        unindentText(start, end);
+      } else {
+        // Tab: Add indentation
+        insertText("  ", start, end);
+      }
+    }
+  }
+
+  function onWindowResize() {
+    measureEditorMetrics();
+    positionOverlays();
+  }
+
+  function onVSCodeMessage(event) {
+    const message = event.data;
+
+    switch (message.type) {
+      case "update":
+        if (message.text !== currentText) {
+          currentText = message.text;
+          editor.value = message.text;
+          if (previewVisible && !message.html) {
+            updatePreview(message.text);
+          }
         }
-    }
-
-    function onEditorInput() {
-        const text = editor.value;
-        currentText = text;
-        
-        // Send update to VS Code
-        vscode.postMessage({
-            type: 'edit',
-            text: text
-        });
-
-        // Update preview
-        if (previewVisible) {
-            updatePreview(text);
+        if (message.html) {
+          renderPreviewHtml(message.html);
+        } else if (previewVisible) {
+          updatePreview(message.text);
         }
+        break;
+      case "togglePreview":
+        togglePreview();
+        break;
+      case "updateOverlays":
+        updateOverlays(message.overlays);
+        break;
+      case "positionUpdate":
+        positionOverlays();
+        break;
+      case "setVisibility":
+        setOverlayVisibility(message.visible);
+        break;
+    }
+  }
+
+  function onPreviewClick(event) {
+    // Handle wiki-link clicks
+    if (event.target.classList.contains("wiki-link")) {
+      event.preventDefault();
+      const linkText = event.target.getAttribute("data-link");
+
+      vscode.postMessage({
+        type: "openWikiLink",
+        link: linkText,
+      });
+    }
+  }
+
+  function requestInitialContent() {
+    vscode.postMessage({ type: "requestContent" });
+  }
+
+  function updatePreview(text) {
+    // Fallback inline renderer used while we wait for the extension to send
+    // the fully rendered HTML. Good enough for fast feedback.
+    let html = text;
+
+    html = html.replace(/^### (.*$)/gim, "<h3>$1</h3>");
+    html = html.replace(/^## (.*$)/gim, "<h2>$1</h2>");
+    html = html.replace(/^# (.*$)/gim, "<h1>$1</h1>");
+    html = html.replace(/\*\*(.*)\*\*/gim, "<strong>$1</strong>");
+    html = html.replace(/\*(.*)\*/gim, "<em>$1</em>");
+    html = html.replace(
+      /\[\[([^\]]+)\]\]/gim,
+      '<a href="#" class="wiki-link" data-link="$1">$1</a>'
+    );
+    html = html.replace(/```(\w+)?\n([\s\S]*?)```/gim, (match, lang, code) => {
+      if (lang === "mermaid") {
+        return `<div class="mermaid-container"><div class="mermaid">${code}</div></div>`;
+      }
+      return `<pre class="code-block"><code class="language-${
+        lang || "text"
+      }">${escapeHtml(code)}</code></pre>`;
+    });
+    html = html.replace(/`([^`]+)`/gim, "<code>$1</code>");
+    html = html.replace(/\n/gim, "<br>");
+
+    renderPreviewHtml(
+      `<div class="markdown-content" data-focus-mode="${focusMode}">${html}</div>`
+    );
+  }
+
+  function renderPreviewHtml(html) {
+    if (typeof html !== "string") {
+      return;
+    }
+    preview.innerHTML = html;
+    renderMermaidInPreview();
+  }
+
+  function escapeHtml(text) {
+    const div = document.createElement("div");
+    div.textContent = text;
+    return div.innerHTML;
+  }
+
+  function togglePreview() {
+    previewVisible = !previewVisible;
+
+    if (previewVisible) {
+      previewPane.style.display = "flex";
+      editorPane.style.borderRight = "1px solid var(--border-color)";
+      togglePreviewBtn.classList.add("active");
+      updatePreview(currentText);
+    } else {
+      previewPane.style.display = "none";
+      editorPane.style.borderRight = "none";
+      togglePreviewBtn.classList.remove("active");
+    }
+  }
+
+  function insertTable() {
+    const tableText = `\n| Column 1 | Column 2 | Column 3 |\n|----------|----------|----------|\n| Cell 1   | Cell 2   | Cell 3   |\n| Cell 4   | Cell 5   | Cell 6   |\n`;
+    insertTextAtCursor(tableText);
+  }
+
+  function insertWikiLink() {
+    const selectedText = getSelectedText();
+    const linkText = selectedText || "Link Text";
+    insertFormatting("[[", "]]", linkText);
+  }
+
+  function toggleFocusMode() {
+    const modes = ["off", "paragraph", "section"];
+    const currentIndex = modes.indexOf(focusMode);
+    focusMode = modes[(currentIndex + 1) % modes.length];
+
+    focusModeBtn.classList.toggle("active", focusMode !== "off");
+
+    if (previewVisible) {
+      updatePreview(currentText);
     }
 
-    function onEditorScroll() {
-        // Sync scroll between editor and preview
-        if (previewVisible) {
-            const scrollPercent = editor.scrollTop / (editor.scrollHeight - editor.clientHeight);
-            preview.scrollTop = scrollPercent * (preview.scrollHeight - preview.clientHeight);
-        }
+    // Send focus mode change to VS Code
+    vscode.postMessage({
+      type: "focusModeChange",
+      mode: focusMode,
+    });
+  }
+
+  function insertMath() {
+    const selectedText = getSelectedText();
+    const isBlock = selectedText.includes("\n") || selectedText.length > 20;
+
+    if (isBlock) {
+      insertFormatting("$$\n", "\n$$", selectedText || "E = mc^2");
+    } else {
+      insertFormatting("$", "$", selectedText || "E = mc^2");
+    }
+  }
+
+  function insertDiagram() {
+    const diagramText = `\n\`\`\`mermaid\ngraph TD\n    A[Start] --> B{Is it?}\n    B -->|Yes| C[OK]\n    B -->|No| D[End]\n\`\`\`\n`;
+    insertTextAtCursor(diagramText);
+  }
+
+  function insertFormatting(prefix, suffix, defaultText) {
+    const start = editor.selectionStart;
+    const end = editor.selectionEnd;
+    const selectedText = editor.value.substring(start, end);
+    const text = selectedText || defaultText;
+
+    const newText = prefix + text + suffix;
+    insertText(newText, start, end);
+
+    // Set cursor position
+    const newCursorPos = start + prefix.length;
+    editor.setSelectionRange(newCursorPos, newCursorPos + text.length);
+    editor.focus();
+  }
+
+  function insertTextAtCursor(text) {
+    const start = editor.selectionStart;
+    const end = editor.selectionEnd;
+    insertText(text, start, end);
+
+    const newCursorPos = start + text.length;
+    editor.setSelectionRange(newCursorPos, newCursorPos);
+    editor.focus();
+  }
+
+  function insertText(text, start, end) {
+    const before = editor.value.substring(0, start);
+    const after = editor.value.substring(end);
+
+    editor.value = before + text + after;
+    currentText = editor.value;
+
+    // Trigger input event
+    const event = new Event("input", { bubbles: true });
+    editor.dispatchEvent(event);
+  }
+
+  function getSelectedText() {
+    const start = editor.selectionStart;
+    const end = editor.selectionEnd;
+    return editor.value.substring(start, end);
+  }
+
+  function unindentText(start, end) {
+    const lines = editor.value.split("\n");
+    const startLine = editor.value.substring(0, start).split("\n").length - 1;
+    const endLine = editor.value.substring(0, end).split("\n").length - 1;
+
+    for (let i = startLine; i <= endLine; i++) {
+      if (lines[i].startsWith("  ")) {
+        lines[i] = lines[i].substring(2);
+      }
     }
 
-    function onEditorKeyDown(event) {
-        // Handle special key combinations
-        if (event.ctrlKey || event.metaKey) {
-            switch (event.key) {
-                case 'b':
-                    event.preventDefault();
-                    insertFormatting('**', '**', 'bold text');
-                    break;
-                case 'i':
-                    event.preventDefault();
-                    insertFormatting('*', '*', 'italic text');
-                    break;
-                case 'k':
-                    event.preventDefault();
-                    insertWikiLink();
-                    break;
-            }
-        }
+    const newText = lines.join("\n");
+    editor.value = newText;
+    currentText = newText;
 
-        // Handle Tab key for indentation
-        if (event.key === 'Tab') {
-            event.preventDefault();
-            const start = editor.selectionStart;
-            const end = editor.selectionEnd;
-            
-            if (event.shiftKey) {
-                // Shift+Tab: Remove indentation
-                unindentText(start, end);
-            } else {
-                // Tab: Add indentation
-                insertText('  ', start, end);
-            }
-        }
+    // Trigger input event
+    const event = new Event("input", { bubbles: true });
+    editor.dispatchEvent(event);
+  }
+
+  // Selective Editing Functions
+  function enableSelectiveEditing() {
+    isSelectiveEditingEnabled = true;
+    preview.addEventListener("click", onPreviewElementClick);
+    updatePreview(currentText); // Re-render with selective editing enabled
+  }
+
+  function disableSelectiveEditing() {
+    isSelectiveEditingEnabled = false;
+    preview.removeEventListener("click", onPreviewElementClick);
+    clearAllEditRegions();
+    updatePreview(currentText); // Re-render without selective editing
+  }
+
+  function onPreviewElementClick(event) {
+    if (!isSelectiveEditingEnabled) return;
+
+    // Don't handle clicks on interactive elements
+    if (
+      event.target.tagName === "A" ||
+      event.target.classList.contains("wiki-link")
+    ) {
+      return;
     }
 
-    function onVSCodeMessage(event) {
-        const message = event.data;
-        
-        switch (message.type) {
-            case 'update':
-                if (message.text !== currentText) {
-                    currentText = message.text;
-                    editor.value = message.text;
-                    if (previewVisible) {
-                        updatePreview(message.text);
-                    }
-                }
-                break;
-            case 'togglePreview':
-                togglePreview();
-                break;
-        }
+    event.preventDefault();
+
+    // Find the clicked element and determine what to edit
+    const clickedElement = event.target;
+    const region = determineEditRegion(clickedElement);
+
+    if (region) {
+      toggleEditRegion(region);
+    }
+  }
+
+  function determineEditRegion(element) {
+    // Walk up the DOM to find the most appropriate editable region
+    let currentElement = element;
+
+    // Look for block-level elements first (highest priority)
+    while (currentElement && currentElement !== preview) {
+      if (isBlockLevelElement(currentElement)) {
+        return createRegionFromElement(currentElement, "block");
+      }
+      currentElement = currentElement.parentElement;
     }
 
-    function onPreviewClick(event) {
-        // Handle wiki-link clicks
-        if (event.target.classList.contains('wiki-link')) {
-            event.preventDefault();
-            const linkText = event.target.getAttribute('data-link');
-            
-            vscode.postMessage({
-                type: 'openWikiLink',
-                link: linkText
-            });
-        }
+    // If no block element found, try line-level
+    currentElement = element;
+    while (currentElement && currentElement !== preview) {
+      if (isLineLevelElement(currentElement)) {
+        return createRegionFromElement(currentElement, "line");
+      }
+      currentElement = currentElement.parentElement;
     }
 
-    function requestInitialContent() {
-        vscode.postMessage({ type: 'requestContent' });
+    // Finally, try word-level
+    if (element.textContent && element.textContent.trim()) {
+      return createRegionFromElement(element, "word");
     }
 
-    function updatePreview(text) {
-        // Simple markdown rendering (this would be enhanced with a proper renderer)
-        let html = text;
-        
-        // Headers
-        html = html.replace(/^### (.*$)/gim, '<h3>$1</h3>');
-        html = html.replace(/^## (.*$)/gim, '<h2>$1</h2>');
-        html = html.replace(/^# (.*$)/gim, '<h1>$1</h1>');
-        
-        // Bold and italic
-        html = html.replace(/\*\*(.*)\*\*/gim, '<strong>$1</strong>');
-        html = html.replace(/\*(.*)\*/gim, '<em>$1</em>');
-        
-        // Wiki links
-        html = html.replace(/\[\[([^\]]+)\]\]/gim, '<a href="#" class="wiki-link" data-link="$1">$1</a>');
-        
-        // Code blocks
-        html = html.replace(/```(\w+)?\n([\s\S]*?)```/gim, (match, lang, code) => {
-            if (lang === 'mermaid') {
-                return `<div class="mermaid-container"><div class="mermaid">${code}</div></div>`;
-            }
-            return `<pre class="code-block"><code class="language-${lang || 'text'}">${escapeHtml(code)}</code></pre>`;
-        });
-        
-        // Inline code
-        html = html.replace(/`([^`]+)`/gim, '<code>$1</code>');
-        
-        // Line breaks
-        html = html.replace(/\n/gim, '<br>');
-        
-        preview.innerHTML = `<div class="markdown-content" data-focus-mode="${focusMode}">${html}</div>`;
-        
-        // Render Mermaid diagrams with error handling
-        if (typeof mermaid !== 'undefined') {
-            try {
-                mermaid.run().catch(error => {
-                    console.error('Mermaid rendering error:', error);
-                    // Find and replace failed diagrams with error messages
-                    const failedDiagrams = document.querySelectorAll('.mermaid[data-processed="true"]');
-                    failedDiagrams.forEach(diagram => {
-                        if (diagram.textContent.includes('syntax error') || diagram.innerHTML.includes('error')) {
-                            diagram.innerHTML = `<div class="diagram-error">
-                                <strong>Mermaid Diagram Error</strong><br>
-                                <small>${error.message || 'Invalid diagram syntax'}</small>
-                            </div>`;
-                        }
-                    });
-                });
-            } catch (error) {
-                console.error('Mermaid initialization error:', error);
-            }
-        }
-    }
+    return null;
+  }
 
-    function escapeHtml(text) {
-        const div = document.createElement('div');
-        div.textContent = text;
-        return div.innerHTML;
-    }
+  function isBlockLevelElement(element) {
+    const blockTags = [
+      "H1",
+      "H2",
+      "H3",
+      "H4",
+      "H5",
+      "H6",
+      "P",
+      "LI",
+      "BLOCKQUOTE",
+      "PRE",
+    ];
+    return (
+      blockTags.includes(element.tagName) ||
+      element.classList.contains("code-block") ||
+      element.classList.contains("mermaid-container")
+    );
+  }
 
-    function togglePreview() {
-        previewVisible = !previewVisible;
-        
-        if (previewVisible) {
-            previewPane.style.display = 'flex';
-            editorPane.style.borderRight = '1px solid var(--border-color)';
-            togglePreviewBtn.classList.add('active');
-            updatePreview(currentText);
-        } else {
-            previewPane.style.display = 'none';
-            editorPane.style.borderRight = 'none';
-            togglePreviewBtn.classList.remove('active');
-        }
-    }
+  function isLineLevelElement(element) {
+    // For now, treat any text-containing element as line-level
+    return (
+      element.textContent &&
+      element.textContent.trim() &&
+      element.children.length === 0
+    );
+  }
 
-    function insertTable() {
-        const tableText = `\n| Column 1 | Column 2 | Column 3 |\n|----------|----------|----------|\n| Cell 1   | Cell 2   | Cell 3   |\n| Cell 4   | Cell 5   | Cell 6   |\n`;
-        insertTextAtCursor(tableText);
-    }
+  function createRegionFromElement(element, type) {
+    // Get the approximate source position for this element
+    const sourcePosition = getSourcePositionFromElement(element);
 
-    function insertWikiLink() {
-        const selectedText = getSelectedText();
-        const linkText = selectedText || 'Link Text';
-        insertFormatting('[[', ']]', linkText);
-    }
+    if (!sourcePosition) return null;
 
-    function toggleFocusMode() {
-        const modes = ['off', 'paragraph', 'section'];
-        const currentIndex = modes.indexOf(focusMode);
-        focusMode = modes[(currentIndex + 1) % modes.length];
-        
-        focusModeBtn.classList.toggle('active', focusMode !== 'off');
-        
-        if (previewVisible) {
-            updatePreview(currentText);
-        }
-
-        // Send focus mode change to VS Code
-        vscode.postMessage({
-            type: 'focusModeChange',
-            mode: focusMode
-        });
-    }
-
-    function insertMath() {
-        const selectedText = getSelectedText();
-        const isBlock = selectedText.includes('\n') || selectedText.length > 20;
-        
-        if (isBlock) {
-            insertFormatting('$$\n', '\n$$', selectedText || 'E = mc^2');
-        } else {
-            insertFormatting('$', '$', selectedText || 'E = mc^2');
-        }
-    }
-
-    function insertDiagram() {
-        const diagramText = `\n\`\`\`mermaid\ngraph TD\n    A[Start] --> B{Is it?}\n    B -->|Yes| C[OK]\n    B -->|No| D[End]\n\`\`\`\n`;
-        insertTextAtCursor(diagramText);
-    }
-
-    function insertFormatting(prefix, suffix, defaultText) {
-        const start = editor.selectionStart;
-        const end = editor.selectionEnd;
-        const selectedText = editor.value.substring(start, end);
-        const text = selectedText || defaultText;
-        
-        const newText = prefix + text + suffix;
-        insertText(newText, start, end);
-        
-        // Set cursor position
-        const newCursorPos = start + prefix.length;
-        editor.setSelectionRange(newCursorPos, newCursorPos + text.length);
-        editor.focus();
-    }
-
-    function insertTextAtCursor(text) {
-        const start = editor.selectionStart;
-        const end = editor.selectionEnd;
-        insertText(text, start, end);
-        
-        const newCursorPos = start + text.length;
-        editor.setSelectionRange(newCursorPos, newCursorPos);
-        editor.focus();
-    }
-
-    function insertText(text, start, end) {
-        const before = editor.value.substring(0, start);
-        const after = editor.value.substring(end);
-        
-        editor.value = before + text + after;
-        currentText = editor.value;
-        
-        // Trigger input event
-        const event = new Event('input', { bubbles: true });
-        editor.dispatchEvent(event);
-    }
-
-    function getSelectedText() {
-        const start = editor.selectionStart;
-        const end = editor.selectionEnd;
-        return editor.value.substring(start, end);
-    }
-
-    function unindentText(start, end) {
-        const lines = editor.value.split('\n');
-        const startLine = editor.value.substring(0, start).split('\n').length - 1;
-        const endLine = editor.value.substring(0, end).split('\n').length - 1;
-        
-        for (let i = startLine; i <= endLine; i++) {
-            if (lines[i].startsWith('  ')) {
-                lines[i] = lines[i].substring(2);
-            }
-        }
-        
-        const newText = lines.join('\n');
-        editor.value = newText;
-        currentText = newText;
-        
-        // Trigger input event
-        const event = new Event('input', { bubbles: true });
-        editor.dispatchEvent(event);
-    }
-
-    // Export for debugging
-    window.markrightEditor = {
-        togglePreview,
-        insertTable,
-        insertWikiLink,
-        toggleFocusMode,
-        insertMath,
-        insertDiagram
+    return {
+      id: nextRegionId++,
+      element: element,
+      type: type,
+      start: sourcePosition.start,
+      end: sourcePosition.end,
+      source: getSourceText(sourcePosition.start, sourcePosition.end),
     };
+  }
+
+  function getSourcePositionFromElement(element) {
+    // This is a simplified mapping - in a real implementation, we'd need
+    // more sophisticated position mapping between rendered HTML and source
+    const elementIndex = Array.from(preview.querySelectorAll("*")).indexOf(
+      element
+    );
+
+    if (elementIndex === -1) return null;
+
+    // Estimate source positions based on element position in document
+    // This is a rough approximation - real implementation would need AST parsing
+    const lines = currentText.split("\n");
+    const estimatedLine = Math.floor(
+      (elementIndex / preview.querySelectorAll("*").length) * lines.length
+    );
+
+    return {
+      start: Math.max(0, estimatedLine),
+      end: Math.min(lines.length - 1, estimatedLine + 2),
+    };
+  }
+
+  function getSourceText(startLine, endLine) {
+    const lines = currentText.split("\n");
+    return lines.slice(startLine, endLine + 1).join("\n");
+  }
+
+  function toggleEditRegion(region) {
+    if (editRegions.has(region.id)) {
+      // Region is already in edit mode, switch back to preview
+      removeEditRegion(region.id);
+    } else {
+      // Switch region to edit mode
+      addEditRegion(region);
+    }
+  }
+
+  function addEditRegion(region) {
+    editRegions.set(region.id, region);
+
+    // Create an inline editor for this region
+    const editorElement = createInlineEditor(region);
+    region.element.replaceWith(editorElement);
+
+    // Focus the new editor
+    setTimeout(() => {
+      editorElement.focus();
+      editorElement.select();
+    }, 10);
+  }
+
+  function removeEditRegion(regionId) {
+    const region = editRegions.get(regionId);
+    if (!region) return;
+
+    // Replace the editor with rendered content
+    const renderedElement = createRenderedElement(region);
+    region.element.replaceWith(renderedElement);
+
+    editRegions.delete(regionId);
+  }
+
+  function createInlineEditor(region) {
+    const textarea = document.createElement("textarea");
+    textarea.className = "inline-editor";
+    textarea.value = region.source;
+    textarea.dataset.regionId = region.id;
+
+    // Position the textarea to match the original element
+    const rect = region.element.getBoundingClientRect();
+    textarea.style.position = "absolute";
+    textarea.style.left = rect.left + "px";
+    textarea.style.top = rect.top + "px";
+    textarea.style.width = rect.width + "px";
+    textarea.style.minHeight = rect.height + "px";
+
+    // Event listeners
+    textarea.addEventListener("blur", () =>
+      handleInlineEditorBlur(region.id, textarea)
+    );
+    textarea.addEventListener("keydown", (e) =>
+      handleInlineEditorKeydown(e, region.id, textarea)
+    );
+
+    return textarea;
+  }
+
+  function createRenderedElement(region) {
+    // Re-render the source text as HTML
+    const tempDiv = document.createElement("div");
+    tempDiv.innerHTML = renderMarkdownToHtml(region.source);
+    return tempDiv.firstElementChild || tempDiv;
+  }
+
+  function renderMarkdownToHtml(text) {
+    // Simple markdown rendering (reuse existing logic)
+    let html = text;
+
+    // Headers
+    html = html.replace(/^### (.*$)/gim, "<h3>$1</h3>");
+    html = html.replace(/^## (.*$)/gim, "<h2>$1</h2>");
+    html = html.replace(/^# (.*$)/gim, "<h1>$1</h1>");
+
+    // Bold and italic
+    html = html.replace(/\*\*(.*)\*\*/gim, "<strong>$1</strong>");
+    html = html.replace(/\*(.*)\*/gim, "<em>$1</em>");
+
+    // Wiki links
+    html = html.replace(
+      /\[\[([^\]]+)\]\]/gim,
+      '<a href="#" class="wiki-link" data-link="$1">$1</a>'
+    );
+
+    // Line breaks
+    html = html.replace(/\n/gim, "<br>");
+
+    return html;
+  }
+
+  function handleInlineEditorBlur(regionId, textarea) {
+    const newSource = textarea.value;
+    updateRegionSource(regionId, newSource);
+    removeEditRegion(regionId);
+  }
+
+  function handleInlineEditorKeydown(event, regionId, textarea) {
+    if (event.key === "Escape") {
+      // Cancel editing
+      removeEditRegion(regionId);
+    } else if (event.key === "Enter" && event.ctrlKey) {
+      // Save and exit
+      handleInlineEditorBlur(regionId, textarea);
+    }
+  }
+
+  function updateRegionSource(regionId, newSource) {
+    const region = editRegions.get(regionId);
+    if (!region) return;
+
+    // Update the source text
+    region.source = newSource;
+
+    // Update the main document
+    const lines = currentText.split("\n");
+    // This is simplified - real implementation would need proper source mapping
+    lines.splice(
+      region.start,
+      region.end - region.start + 1,
+      ...newSource.split("\n")
+    );
+    currentText = lines.join("\n");
+
+    // Update the main editor
+    editor.value = currentText;
+
+    // Notify VS Code of the change
+    vscode.postMessage({
+      type: "edit",
+      text: currentText,
+    });
+  }
+
+  function clearAllEditRegions() {
+    for (const regionId of editRegions.keys()) {
+      removeEditRegion(regionId);
+    }
+  }
+
+  // Export for debugging
+  window.markrightEditor = {
+    togglePreview,
+    insertTable,
+    insertWikiLink,
+    toggleFocusMode,
+    insertMath,
+    insertDiagram,
+  };
+
+  // Overlay functionality
+  let currentOverlays = [];
+  let overlayVisibility = true;
+
+  function updateOverlays(overlays) {
+    currentOverlays = Array.isArray(overlays) ? overlays : [];
+    measureEditorMetrics();
+    renderOverlays();
+    updateOverlayVisibilityForCaret();
+  }
+
+  function setOverlayVisibility(visible) {
+    overlayVisibility = visible;
+    if (overlayContainer) {
+      overlayContainer.style.display = visible ? "block" : "none";
+      if (visible) {
+        positionOverlays();
+      }
+    }
+    applyOverlayEditorStyles();
+  }
+
+  function renderOverlays() {
+    const overlayContainer = document.getElementById("overlay-container");
+    if (!overlayContainer) return;
+
+    // Clear existing overlays
+    overlayContainer.innerHTML = "";
+
+    if (!overlayVisibility) {
+      applyOverlayEditorStyles();
+      return;
+    }
+
+    currentOverlays.forEach((overlay, index) => {
+      const overlayElement = createOverlayElement(overlay, index);
+      if (overlayElement) {
+        overlayContainer.appendChild(overlayElement);
+        if (overlay.type === "diagram") {
+          const diagramSource = overlay.rendered || overlay.content || "";
+          renderMermaidOverlay(overlayElement, diagramSource, index);
+        }
+      }
+    });
+
+    positionOverlays();
+    applyOverlayEditorStyles();
+  }
+
+  function createOverlayElement(overlay, index) {
+    if (!overlay || !overlay.range || typeof overlay.range.start !== "object") {
+      return null;
+    }
+
+    const element = document.createElement("div");
+    element.className = `floating-overlay ${overlay.type}`;
+    element.dataset.type = overlay.type;
+    element.dataset.index = String(index);
+
+    const startLine = overlay.range.start?.line ?? 0;
+    const endLine = overlay.range.end?.line ?? startLine;
+    element.dataset.startLine = String(startLine);
+    element.dataset.endLine = String(endLine);
+
+    if (overlay.type === "heading" && overlay.level) {
+      element.classList.add("heading");
+      element.classList.add(`h${overlay.level}`);
+      element.textContent = overlay.rendered || overlay.content || "";
+      const sizes = {
+        1: { fontSize: "26px", fontWeight: 700 },
+        2: { fontSize: "22px", fontWeight: 700 },
+        3: { fontSize: "19px", fontWeight: 600 },
+        4: { fontSize: "17px", fontWeight: 600 },
+        5: { fontSize: "15px", fontWeight: 600 },
+        6: { fontSize: "14px", fontWeight: 600 },
+      };
+      const styling = sizes[overlay.level] || sizes[1];
+      element.style.fontSize = styling.fontSize;
+      element.style.fontWeight = styling.fontWeight;
+      element.style.background = "transparent";
+      element.style.boxShadow = "none";
+      element.style.padding = "0";
+    } else if (overlay.type === "table") {
+      element.innerHTML = overlay.rendered || "";
+    } else if (overlay.type === "latex") {
+      element.innerHTML = `<div class="latex">${overlay.rendered || overlay.content || ""}</div>`;
+    } else if (overlay.type === "diagram") {
+      element.classList.add("diagram");
+      element.innerHTML = `<div class="mermaid" data-mermaid-index="${index}">${
+        overlay.rendered || overlay.content || ""
+      }</div>`;
+    }
+
+    return element;
+  }
+
+  function renderMermaidOverlay(container, code, index) {
+    if (typeof mermaid === "undefined") {
+      container.innerHTML = `<pre class="mermaid">${escapeHtml(code)}</pre>`;
+      return;
+    }
+
+    const renderId = `markright-overlay-${Date.now()}-${index}`;
+    const targetNode = container.querySelector(".mermaid");
+    if (!targetNode) {
+      container.innerHTML = `<pre class="mermaid">${escapeHtml(code)}</pre>`;
+      return;
+    }
+
+    try {
+      mermaid
+        .render(renderId, code)
+        .then(({ svg }) => {
+          targetNode.innerHTML = svg;
+          positionOverlays();
+        })
+        .catch((error) => {
+          console.error("Mermaid overlay render error", error);
+          container.innerHTML = `<pre class="mermaid">${escapeHtml(code)}</pre>`;
+        });
+    } catch (error) {
+      console.error("Mermaid overlay render error", error);
+      container.innerHTML = `<pre class="mermaid">${escapeHtml(code)}</pre>`;
+    }
+  }
+
+  function positionOverlays() {
+    if (!overlayContainer || !editor || !overlayVisibility) {
+      return;
+    }
+
+    overlayContainer.style.height = `${editor.scrollHeight}px`;
+    overlayContainer.style.width = `${editor.clientWidth}px`;
+
+    const scrollTop = editor.scrollTop;
+    const viewHeight = editor.clientHeight;
+    const lineHeight = editorLineHeight || 20;
+    const visibleStart = Math.floor(scrollTop / lineHeight);
+    const visibleEnd = Math.ceil((scrollTop + viewHeight) / lineHeight);
+
+    overlayContainer.querySelectorAll(".floating-overlay").forEach((element) => {
+      const startLine = parseInt(element.dataset.startLine || "0", 10);
+      const endLine = parseInt(element.dataset.endLine || String(startLine), 10);
+
+      if (endLine < visibleStart || startLine > visibleEnd) {
+        element.classList.add("hidden");
+        return;
+      }
+
+      element.classList.remove("hidden");
+
+      const offsetTop = startLine * lineHeight - scrollTop;
+      element.style.top = `${offsetTop}px`;
+      element.style.left = `${editorPaddingLeft}px`;
+    });
+  }
+
+  function measureEditorMetrics() {
+    if (!editor || !overlayContainer) {
+      return;
+    }
+
+    const style = window.getComputedStyle(editor);
+    const lineHeight = parseFloat(style.lineHeight);
+    editorLineHeight = Number.isFinite(lineHeight) ? lineHeight : 20;
+    editorPaddingLeft = parseFloat(style.paddingLeft) || 0;
+
+    overlayContainer.style.width = `${editor.clientWidth}px`;
+    overlayContainer.style.height = `${editor.scrollHeight}px`;
+  }
+
+  function applyOverlayEditorStyles() {
+    if (!editor) {
+      return;
+    }
+
+    const shouldHideSource = overlayVisibility && currentOverlays.length > 0;
+    editor.classList.toggle("overlay-active", shouldHideSource);
+  }
+
+  function updateOverlayVisibilityForCaret() {
+    if (!editor) {
+      return;
+    }
+
+    if (!currentOverlays.length) {
+      applyOverlayEditorStyles();
+      return;
+    }
+
+    const caretLine = getCaretLine();
+    if (caretLine === null) {
+      return;
+    }
+
+    const caretInsideOverlay = currentOverlays.some((overlay) => {
+      if (!overlay || !overlay.range || !overlay.range.start) {
+        return false;
+      }
+      const startLine = overlay.range.start.line ?? 0;
+      const endLine = overlay.range.end?.line ?? startLine;
+      return caretLine >= startLine && caretLine <= endLine;
+    });
+
+    if (caretInsideOverlay) {
+      if (overlayVisibility) {
+        setOverlayVisibility(false);
+      }
+    } else if (!overlayVisibility) {
+      setOverlayVisibility(true);
+    }
+  }
+
+  function getCaretLine() {
+    if (!editor || typeof editor.selectionStart !== "number") {
+      return null;
+    }
+
+    const beforeCaret = editor.value.slice(0, editor.selectionStart);
+    return beforeCaret.split("\n").length - 1;
+  }
+
+  function renderMermaidInPreview() {
+    if (typeof mermaid === "undefined") {
+      return;
+    }
+
+    const nodes = preview.querySelectorAll(
+      ".mermaid:not([data-processed])"
+    );
+    nodes.forEach((node, index) => {
+      const code = node.textContent;
+      if (!code) {
+        return;
+      }
+      const renderId = `markright-preview-${Date.now()}-${index}`;
+      try {
+        mermaid
+          .render(renderId, code)
+          .then(({ svg }) => {
+            node.innerHTML = svg;
+            node.setAttribute("data-processed", "true");
+          })
+          .catch((error) => {
+            console.error("Mermaid preview render error", error);
+            node.innerHTML = `<pre class="mermaid">${escapeHtml(code)}</pre>`;
+          });
+      } catch (error) {
+        console.error("Mermaid preview render error", error);
+        node.innerHTML = `<pre class="mermaid">${escapeHtml(code)}</pre>`;
+      }
+    });
+  }
 })();

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,16 +18,16 @@
         "@types/katex": "^0.16.7",
         "@types/marked": "^5.0.2",
         "@types/mocha": "^10.0.10",
-        "@types/node": "16.x",
+        "@types/node": "18.x",
         "@types/vscode": "^1.74.0",
-        "@typescript-eslint/eslint-plugin": "^5.45.0",
-        "@typescript-eslint/parser": "^5.45.0",
+        "@typescript-eslint/eslint-plugin": "^7.0.0",
+        "@typescript-eslint/parser": "^7.0.0",
         "@vscode/test-electron": "^2.5.2",
-        "eslint": "^8.28.0",
+        "eslint": "^8.57.0",
         "glob": "^11.0.3",
         "mocha": "^11.7.2",
-        "ts-loader": "^9.4.1",
-        "typescript": "^4.9.4",
+        "ts-loader": "^9.5.1",
+        "typescript": "^5.9.0",
         "webpack": "^5.75.0",
         "webpack-cli": "^5.0.1"
       },
@@ -453,18 +453,14 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "16.18.126",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.126.tgz",
-      "integrity": "sha512-OTcgaiwfGFBKacvfwuHzzn1KLxH/er8mluiy8/uM3sGXHaRe73RrSIj01jow9t4kJEW633Ov+cOexXeiApTyAw==",
+      "version": "18.19.124",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.124.tgz",
+      "integrity": "sha512-hY4YWZFLs3ku6D2Gqo3RchTd9VRCcrjqp/I0mmohYeUVA5Y8eCXKJEasHxLAJVZRJuQogfd1GiJ9lgogBgKeuQ==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==",
-      "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "node_modules/@types/vscode": {
       "version": "1.104.0",
@@ -474,33 +470,32 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "5.62.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.62.0.tgz",
-      "integrity": "sha512-TiZzBSJja/LbhNPvk6yc0JrX9XqhQ0hdh6M2svYfsHGejaKFIAGd9MQ+ERIMzLGlN/kZoYIgdxFV0PuljTKXag==",
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.18.0.tgz",
+      "integrity": "sha512-94EQTWZ40mzBc42ATNIBimBEDltSJ9RQHCC8vc/PDbxi4k8dVwUAv4o98dk50M1zB+JGFxp43FP7f8+FP8R6Sw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-community/regexpp": "^4.4.0",
-        "@typescript-eslint/scope-manager": "5.62.0",
-        "@typescript-eslint/type-utils": "5.62.0",
-        "@typescript-eslint/utils": "5.62.0",
-        "debug": "^4.3.4",
+        "@eslint-community/regexpp": "^4.10.0",
+        "@typescript-eslint/scope-manager": "7.18.0",
+        "@typescript-eslint/type-utils": "7.18.0",
+        "@typescript-eslint/utils": "7.18.0",
+        "@typescript-eslint/visitor-keys": "7.18.0",
         "graphemer": "^1.4.0",
-        "ignore": "^5.2.0",
-        "natural-compare-lite": "^1.4.0",
-        "semver": "^7.3.7",
-        "tsutils": "^3.21.0"
+        "ignore": "^5.3.1",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^1.3.0"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^18.18.0 || >=20.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^5.0.0",
-        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+        "@typescript-eslint/parser": "^7.0.0",
+        "eslint": "^8.56.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -509,26 +504,27 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "5.62.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.62.0.tgz",
-      "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.18.0.tgz",
+      "integrity": "sha512-4Z+L8I2OqhZV8qA132M4wNL30ypZGYOQVBfMgxDH/K5UX0PNqTu1c6za9ST5r9+tavvHiTWmBnKzpCJ/GlVFtg==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.62.0",
-        "@typescript-eslint/types": "5.62.0",
-        "@typescript-eslint/typescript-estree": "5.62.0",
+        "@typescript-eslint/scope-manager": "7.18.0",
+        "@typescript-eslint/types": "7.18.0",
+        "@typescript-eslint/typescript-estree": "7.18.0",
+        "@typescript-eslint/visitor-keys": "7.18.0",
         "debug": "^4.3.4"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^18.18.0 || >=20.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+        "eslint": "^8.56.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -537,17 +533,17 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.62.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.62.0.tgz",
-      "integrity": "sha512-VXuvVvZeQCQb5Zgf4HAxc04q5j+WrNAtNh9OwCsCgpKqESMTu3tF/jhZ3xG6T4NZwWl65Bg8KuS2uEvhSfLl0w==",
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.18.0.tgz",
+      "integrity": "sha512-jjhdIE/FPF2B7Z1uzc6i3oWKbGcHb87Qw7AWj6jmEqNOfDFbJWtjt/XfwCpvNkpGWlcJaog5vTR+VV8+w9JflA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "5.62.0",
-        "@typescript-eslint/visitor-keys": "5.62.0"
+        "@typescript-eslint/types": "7.18.0",
+        "@typescript-eslint/visitor-keys": "7.18.0"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^18.18.0 || >=20.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -555,26 +551,26 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "5.62.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.62.0.tgz",
-      "integrity": "sha512-xsSQreu+VnfbqQpW5vnCJdq1Z3Q0U31qiWmRhr98ONQmcp/yhiPJFPq8MXiJVLiksmOKSjIldZzkebzHuCGzew==",
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.18.0.tgz",
+      "integrity": "sha512-XL0FJXuCLaDuX2sYqZUUSOJ2sG5/i1AAze+axqmLnSkNEVMVYLF+cbwlB2w8D1tinFuSikHmFta+P+HOofrLeA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "5.62.0",
-        "@typescript-eslint/utils": "5.62.0",
+        "@typescript-eslint/typescript-estree": "7.18.0",
+        "@typescript-eslint/utils": "7.18.0",
         "debug": "^4.3.4",
-        "tsutils": "^3.21.0"
+        "ts-api-utils": "^1.3.0"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^18.18.0 || >=20.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "*"
+        "eslint": "^8.56.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -583,13 +579,13 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "5.62.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.62.0.tgz",
-      "integrity": "sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ==",
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.18.0.tgz",
+      "integrity": "sha512-iZqi+Ds1y4EDYUtlOOC+aUmxnE9xS/yCigkjA7XpTKV6nCBd3Hp/PRGGmdwnfkV2ThMyYldP1wRpm/id99spTQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^18.18.0 || >=20.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -597,22 +593,23 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.62.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.62.0.tgz",
-      "integrity": "sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==",
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.18.0.tgz",
+      "integrity": "sha512-aP1v/BSPnnyhMHts8cf1qQ6Q1IFwwRvAQGRvBFkWlo3/lH29OXA3Pts+c10nxRxIBrDnoMqzhgdwVe5f2D6OzA==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "@typescript-eslint/types": "5.62.0",
-        "@typescript-eslint/visitor-keys": "5.62.0",
+        "@typescript-eslint/types": "7.18.0",
+        "@typescript-eslint/visitor-keys": "7.18.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
-        "semver": "^7.3.7",
-        "tsutils": "^3.21.0"
+        "minimatch": "^9.0.4",
+        "semver": "^7.6.0",
+        "ts-api-utils": "^1.3.0"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^18.18.0 || >=20.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -624,45 +621,67 @@
         }
       }
     },
-    "node_modules/@typescript-eslint/utils": {
-      "version": "5.62.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.62.0.tgz",
-      "integrity": "sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==",
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-community/eslint-utils": "^4.2.0",
-        "@types/json-schema": "^7.0.9",
-        "@types/semver": "^7.3.12",
-        "@typescript-eslint/scope-manager": "5.62.0",
-        "@typescript-eslint/types": "5.62.0",
-        "@typescript-eslint/typescript-estree": "5.62.0",
-        "eslint-scope": "^5.1.1",
-        "semver": "^7.3.7"
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.18.0.tgz",
+      "integrity": "sha512-kK0/rNa2j74XuHVcoCZxdFBMF+aq/vH83CXAOHieC+2Gis4mF8jJXT5eAfyD3K0sAxtPuwxaIOIOvhwzVDt/kw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "@typescript-eslint/scope-manager": "7.18.0",
+        "@typescript-eslint/types": "7.18.0",
+        "@typescript-eslint/typescript-estree": "7.18.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+        "eslint": "^8.56.0"
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.62.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.62.0.tgz",
-      "integrity": "sha512-07ny+LHRzQXepkGg6w0mFY41fVUNBrL2Roj/++7V1txKugfjm/Ci/qSND03r2RhlJhJYMcTn9AhhSSqQp0Ysyw==",
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.18.0.tgz",
+      "integrity": "sha512-cDF0/Gf81QpY3xYyJKDV14Zwdmid5+uuENhjH2EqFaF0ni+yAyq/LzMaIJdhNJXZI7uLzwIlA+V7oWoyn6Curg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "5.62.0",
-        "eslint-visitor-keys": "^3.3.0"
+        "@typescript-eslint/types": "7.18.0",
+        "eslint-visitor-keys": "^3.4.3"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^18.18.0 || >=20.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -3409,13 +3428,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/natural-compare-lite": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
-      "integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/neo-async": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
@@ -4567,6 +4579,19 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/ts-api-utils": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.4.3.tgz",
+      "integrity": "sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.2.0"
+      }
+    },
     "node_modules/ts-dedent": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.2.0.tgz",
@@ -4597,29 +4622,6 @@
         "webpack": "^5.0.0"
       }
     },
-    "node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true,
-      "license": "0BSD"
-    },
-    "node_modules/tsutils": {
-      "version": "3.21.0",
-      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
-      "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^1.8.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      },
-      "peerDependencies": {
-        "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
-      }
-    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -4647,9 +4649,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -4657,8 +4659,15 @@
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,18 @@
   ],
   "main": "./dist/extension.js",
   "contributes": {
+    "customEditors": [
+      {
+        "viewType": "markright.markdownEditor",
+        "displayName": "MarkRight Editor",
+        "selector": [
+          {
+            "filenamePattern": "*.md"
+          }
+        ],
+        "priority": "option"
+      }
+    ],
     "commands": [
       {
         "command": "markright.openEditor",
@@ -136,16 +148,16 @@
     "@types/katex": "^0.16.7",
     "@types/marked": "^5.0.2",
     "@types/mocha": "^10.0.10",
-    "@types/node": "16.x",
+    "@types/node": "18.x",
     "@types/vscode": "^1.74.0",
-    "@typescript-eslint/eslint-plugin": "^5.45.0",
-    "@typescript-eslint/parser": "^5.45.0",
+    "@typescript-eslint/eslint-plugin": "^7.0.0",
+    "@typescript-eslint/parser": "^7.0.0",
     "@vscode/test-electron": "^2.5.2",
-    "eslint": "^8.28.0",
+    "eslint": "^8.57.0",
     "glob": "^11.0.3",
     "mocha": "^11.7.2",
-    "ts-loader": "^9.4.1",
-    "typescript": "^4.9.4",
+    "ts-loader": "^9.5.1",
+    "typescript": "^5.9.0",
     "webpack": "^5.75.0",
     "webpack-cli": "^5.0.1"
   },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,54 +1,69 @@
-import * as vscode from 'vscode';
-import { MarkdownEditorProvider } from './markdownEditorProvider';
-import { WikiLinkProvider } from './features/wikiLinkProvider';
-import { FocusModeProvider } from './features/focusModeProvider';
+import * as vscode from "vscode";
+import { MarkdownEditorProvider } from "./markdownEditorProvider";
+import { WikiLinkProvider } from "./features/wikiLinkProvider";
+import { FocusModeProvider } from "./features/focusModeProvider";
+import { SyntaxOverlayProvider } from "./features/syntaxOverlayProvider";
 
 export function activate(context: vscode.ExtensionContext) {
-	console.log('MarkRight extension is now active!');
+  console.log("MarkRight extension is now active!");
 
-	// Register the markdown editor provider
-	const provider = new MarkdownEditorProvider(context.extensionUri);
-	context.subscriptions.push(
-		vscode.window.registerCustomEditorProvider(MarkdownEditorProvider.viewType, provider)
-	);
+  // Register the markdown editor provider
+  const provider = new MarkdownEditorProvider(context);
+  context.subscriptions.push(
+    vscode.window.registerCustomEditorProvider(
+      MarkdownEditorProvider.viewType,
+      provider
+    )
+  );
 
-	// Register wiki link provider
-	const wikiLinkProvider = new WikiLinkProvider();
-	context.subscriptions.push(wikiLinkProvider);
+  // Register wiki link provider
+  const wikiLinkProvider = new WikiLinkProvider();
+  context.subscriptions.push(wikiLinkProvider);
 
-	// Register focus mode provider
-	const focusModeProvider = new FocusModeProvider();
-	context.subscriptions.push(focusModeProvider);
+  // Register focus mode provider
+  const focusModeProvider = new FocusModeProvider();
+  context.subscriptions.push(focusModeProvider);
 
-	// Register commands
-	context.subscriptions.push(
-		vscode.commands.registerCommand('markright.openEditor', () => {
-			const activeEditor = vscode.window.activeTextEditor;
-			if (activeEditor && activeEditor.document.languageId === 'markdown') {
-				vscode.commands.executeCommand('vscode.openWith', activeEditor.document.uri, MarkdownEditorProvider.viewType);
-			} else {
-				vscode.window.showInformationMessage('Please open a markdown file first');
-			}
-		})
-	);
+  // Register syntax overlay provider for typography enhancements
+  const syntaxOverlayProvider = new SyntaxOverlayProvider(context);
+  syntaxOverlayProvider.setCustomEditorProvider(provider);
+  context.subscriptions.push(syntaxOverlayProvider);
 
-	context.subscriptions.push(
-		vscode.commands.registerCommand('markright.insertWikiLink', () => {
-			wikiLinkProvider.insertWikiLink();
-		})
-	);
+  // Register commands
+  context.subscriptions.push(
+    vscode.commands.registerCommand("markright.openEditor", () => {
+      const activeEditor = vscode.window.activeTextEditor;
+      if (activeEditor && activeEditor.document.languageId === "markdown") {
+        vscode.commands.executeCommand(
+          "vscode.openWith",
+          activeEditor.document.uri,
+          MarkdownEditorProvider.viewType
+        );
+      } else {
+        vscode.window.showInformationMessage(
+          "Please open a markdown file first"
+        );
+      }
+    })
+  );
 
-	context.subscriptions.push(
-		vscode.commands.registerCommand('markright.toggleFocusMode', () => {
-			focusModeProvider.toggleFocusMode();
-		})
-	);
+  context.subscriptions.push(
+    vscode.commands.registerCommand("markright.insertWikiLink", () => {
+      wikiLinkProvider.insertWikiLink();
+    })
+  );
 
-	context.subscriptions.push(
-		vscode.commands.registerCommand('markright.togglePreview', () => {
-			provider.togglePreview();
-		})
-	);
+  context.subscriptions.push(
+    vscode.commands.registerCommand("markright.toggleFocusMode", () => {
+      focusModeProvider.toggleFocusMode();
+    })
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand("markright.togglePreview", () => {
+      provider.togglePreview();
+    })
+  );
 }
 
 export function deactivate() {}

--- a/src/features/focusModeProvider.ts
+++ b/src/features/focusModeProvider.ts
@@ -1,205 +1,246 @@
-import * as vscode from 'vscode';
+import * as vscode from "vscode";
 
 export class FocusModeProvider implements vscode.Disposable {
-	private disposables: vscode.Disposable[] = [];
-	private decorationType: vscode.TextEditorDecorationType;
-	private currentFocusMode: 'off' | 'paragraph' | 'section' = 'off';
+  private disposables: vscode.Disposable[] = [];
+  private decorationType: vscode.TextEditorDecorationType;
+  private currentFocusMode: "off" | "paragraph" | "section" = "off";
 
-	constructor() {
-		this.decorationType = vscode.window.createTextEditorDecorationType({
-			backgroundColor: 'rgba(128, 128, 128, 0.1)',
-			opacity: '0.5'
-		});
+  constructor() {
+    this.decorationType = vscode.window.createTextEditorDecorationType({
+      backgroundColor: "rgba(128, 128, 128, 0.1)",
+      opacity: "0.5",
+    });
 
-		this.registerListeners();
-	}
+    this.registerListeners();
+  }
 
-	private registerListeners() {
-		// Update focus highlighting when cursor moves
-		this.disposables.push(
-			vscode.window.onDidChangeTextEditorSelection(this.onSelectionChange.bind(this))
-		);
+  private registerListeners() {
+    // Update focus highlighting when cursor moves
+    this.disposables.push(
+      vscode.window.onDidChangeTextEditorSelection(
+        this.onSelectionChange.bind(this)
+      )
+    );
 
-		// Update focus highlighting when document changes
-		this.disposables.push(
-			vscode.workspace.onDidChangeTextDocument(this.onDocumentChange.bind(this))
-		);
+    // Update focus highlighting when document changes
+    this.disposables.push(
+      vscode.workspace.onDidChangeTextDocument(this.onDocumentChange.bind(this))
+    );
 
-		// Update focus highlighting when configuration changes
-		this.disposables.push(
-			vscode.workspace.onDidChangeConfiguration(this.onConfigurationChange.bind(this))
-		);
-	}
+    // Update focus highlighting when configuration changes
+    this.disposables.push(
+      vscode.workspace.onDidChangeConfiguration(
+        this.onConfigurationChange.bind(this)
+      )
+    );
+  }
 
-	private onSelectionChange(event: vscode.TextEditorSelectionChangeEvent) {
-		if (event.textEditor.document.languageId === 'markdown') {
-			this.updateFocusHighlight(event.textEditor);
-		}
-	}
+  private onSelectionChange(event: vscode.TextEditorSelectionChangeEvent) {
+    if (event.textEditor.document.languageId === "markdown") {
+      this.updateFocusHighlight(event.textEditor);
+    }
+  }
 
-	private onDocumentChange(event: vscode.TextDocumentChangeEvent) {
-		const editor = vscode.window.activeTextEditor;
-		if (editor && editor.document === event.document && event.document.languageId === 'markdown') {
-			this.updateFocusHighlight(editor);
-		}
-	}
+  private onDocumentChange(event: vscode.TextDocumentChangeEvent) {
+    const editor = vscode.window.activeTextEditor;
+    if (
+      editor &&
+      editor.document === event.document &&
+      event.document.languageId === "markdown"
+    ) {
+      this.updateFocusHighlight(editor);
+    }
+  }
 
-	private onConfigurationChange(event: vscode.ConfigurationChangeEvent) {
-		if (event.affectsConfiguration('markright.focusMode')) {
-			const config = vscode.workspace.getConfiguration('markright');
-			this.currentFocusMode = config.get('focusMode', 'off') as 'off' | 'paragraph' | 'section';
-			
-			const editor = vscode.window.activeTextEditor;
-			if (editor && editor.document.languageId === 'markdown') {
-				this.updateFocusHighlight(editor);
-			}
-		}
-	}
+  private onConfigurationChange(event: vscode.ConfigurationChangeEvent) {
+    if (event.affectsConfiguration("markright.focusMode")) {
+      const config = vscode.workspace.getConfiguration("markright");
+      this.currentFocusMode = config.get("focusMode", "off") as
+        | "off"
+        | "paragraph"
+        | "section";
 
-	private updateFocusHighlight(editor: vscode.TextEditor) {
-		if (this.currentFocusMode === 'off') {
-			editor.setDecorations(this.decorationType, []);
-			return;
-		}
+      const editor = vscode.window.activeTextEditor;
+      if (editor && editor.document.languageId === "markdown") {
+        this.updateFocusHighlight(editor);
+      }
+    }
+  }
 
-		const document = editor.document;
-		const selection = editor.selection;
-		const currentLine = selection.active.line;
+  private updateFocusHighlight(editor: vscode.TextEditor) {
+    if (this.currentFocusMode === "off") {
+      editor.setDecorations(this.decorationType, []);
+      return;
+    }
 
-		let focusRange: vscode.Range;
+    const document = editor.document;
+    const selection = editor.selection;
+    const currentLine = selection.active.line;
 
-		if (this.currentFocusMode === 'paragraph') {
-			focusRange = this.getParagraphRange(document, currentLine);
-		} else if (this.currentFocusMode === 'section') {
-			focusRange = this.getSectionRange(document, currentLine);
-		} else {
-			return;
-		}
+    let focusRange: vscode.Range;
 
-		// Create decorations for lines outside the focus range
-		const decorations: vscode.DecorationOptions[] = [];
-		
-		// Lines before focus range
-		if (focusRange.start.line > 0) {
-			decorations.push({
-				range: new vscode.Range(0, 0, focusRange.start.line, 0)
-			});
-		}
+    if (this.currentFocusMode === "paragraph") {
+      focusRange = this.getParagraphRange(document, currentLine);
+    } else if (this.currentFocusMode === "section") {
+      focusRange = this.getSectionRange(document, currentLine);
+    } else {
+      return;
+    }
 
-		// Lines after focus range
-		if (focusRange.end.line < document.lineCount - 1) {
-			decorations.push({
-				range: new vscode.Range(focusRange.end.line + 1, 0, document.lineCount, 0)
-			});
-		}
+    // Create decorations for lines outside the focus range
+    const decorations: vscode.DecorationOptions[] = [];
 
-		editor.setDecorations(this.decorationType, decorations);
-	}
+    // Lines before focus range
+    if (focusRange.start.line > 0) {
+      decorations.push({
+        range: new vscode.Range(0, 0, focusRange.start.line, 0),
+      });
+    }
 
-	private getParagraphRange(document: vscode.TextDocument, currentLine: number): vscode.Range {
-		let startLine = currentLine;
-		let endLine = currentLine;
+    // Lines after focus range
+    if (focusRange.end.line < document.lineCount - 1) {
+      decorations.push({
+        range: new vscode.Range(
+          focusRange.end.line + 1,
+          0,
+          document.lineCount,
+          0
+        ),
+      });
+    }
 
-		// Find start of paragraph (empty line or start of document)
-		while (startLine > 0) {
-			const line = document.lineAt(startLine - 1);
-			if (line.text.trim() === '') {
-				break;
-			}
-			startLine--;
-		}
+    editor.setDecorations(this.decorationType, decorations);
+  }
 
-		// Find end of paragraph (empty line or end of document)
-		while (endLine < document.lineCount - 1) {
-			const line = document.lineAt(endLine + 1);
-			if (line.text.trim() === '') {
-				break;
-			}
-			endLine++;
-		}
+  private getParagraphRange(
+    document: vscode.TextDocument,
+    currentLine: number
+  ): vscode.Range {
+    let startLine = currentLine;
+    let endLine = currentLine;
 
-		return new vscode.Range(startLine, 0, endLine, document.lineAt(endLine).text.length);
-	}
+    // Find start of paragraph (empty line or start of document)
+    while (startLine > 0) {
+      const line = document.lineAt(startLine - 1);
+      if (line.text.trim() === "") {
+        break;
+      }
+      startLine--;
+    }
 
-	private getSectionRange(document: vscode.TextDocument, currentLine: number): vscode.Range {
-		let startLine = 0;
-		let endLine = document.lineCount - 1;
+    // Find end of paragraph (empty line or end of document)
+    while (endLine < document.lineCount - 1) {
+      const line = document.lineAt(endLine + 1);
+      if (line.text.trim() === "") {
+        break;
+      }
+      endLine++;
+    }
 
-		// Find current section based on markdown headers
-		const currentSectionLevel = this.getCurrentSectionLevel(document, currentLine);
-		
-		// Find start of current section
-		for (let i = currentLine; i >= 0; i--) {
-			const line = document.lineAt(i);
-			const headerMatch = line.text.match(/^(#{1,6})\s/);
-			if (headerMatch) {
-				const level = headerMatch[1].length;
-				if (level <= currentSectionLevel) {
-					startLine = i;
-					break;
-				}
-			}
-		}
+    return new vscode.Range(
+      startLine,
+      0,
+      endLine,
+      document.lineAt(endLine)?.text.length || 0
+    );
+  }
 
-		// Find end of current section
-		for (let i = currentLine + 1; i < document.lineCount; i++) {
-			const line = document.lineAt(i);
-			const headerMatch = line.text.match(/^(#{1,6})\s/);
-			if (headerMatch) {
-				const level = headerMatch[1].length;
-				if (level <= currentSectionLevel) {
-					endLine = i - 1;
-					break;
-				}
-			}
-		}
+  private getSectionRange(
+    document: vscode.TextDocument,
+    currentLine: number
+  ): vscode.Range {
+    let startLine = 0;
+    let endLine = document.lineCount - 1;
 
-		return new vscode.Range(startLine, 0, endLine, document.lineAt(endLine).text.length);
-	}
+    // Find current section based on markdown headers
+    const currentSectionLevel = this.getCurrentSectionLevel(
+      document,
+      currentLine
+    );
 
-	private getCurrentSectionLevel(document: vscode.TextDocument, currentLine: number): number {
-		// Find the header that defines the current section
-		for (let i = currentLine; i >= 0; i--) {
-			const line = document.lineAt(i);
-			const headerMatch = line.text.match(/^(#{1,6})\s/);
-			if (headerMatch) {
-				return headerMatch[1].length;
-			}
-		}
-		return 1; // Default to top level if no header found
-	}
+    // Find start of current section
+    for (let i = currentLine; i >= 0; i--) {
+      const line = document.lineAt(i);
+      const headerMatch = line.text.match(/^(#{1,6})\s/);
+      if (headerMatch && headerMatch[1]) {
+        const level = headerMatch[1].length;
+        if (level <= currentSectionLevel) {
+          startLine = i;
+          break;
+        }
+      }
+    }
 
-	public toggleFocusMode(): void {
-		const config = vscode.workspace.getConfiguration('markright');
-		const currentMode = config.get('focusMode', 'off') as 'off' | 'paragraph' | 'section';
-		
-		let newMode: 'off' | 'paragraph' | 'section';
-		switch (currentMode) {
-			case 'off':
-				newMode = 'paragraph';
-				break;
-			case 'paragraph':
-				newMode = 'section';
-				break;
-			case 'section':
-			default:
-				newMode = 'off';
-				break;
-		}
+    // Find end of current section
+    for (let i = currentLine + 1; i < document.lineCount; i++) {
+      const line = document.lineAt(i);
+      const headerMatch = line.text.match(/^(#{1,6})\s/);
+      if (headerMatch && headerMatch[1]) {
+        const level = headerMatch[1].length;
+        if (level <= currentSectionLevel) {
+          endLine = i - 1;
+          break;
+        }
+      }
+    }
 
-		config.update('focusMode', newMode, vscode.ConfigurationTarget.Global);
-		this.currentFocusMode = newMode;
+    return new vscode.Range(
+      startLine,
+      0,
+      endLine,
+      document.lineAt(endLine)?.text.length || 0
+    );
+  }
 
-		vscode.window.showInformationMessage(`Focus mode: ${newMode}`);
+  private getCurrentSectionLevel(
+    document: vscode.TextDocument,
+    currentLine: number
+  ): number {
+    // Find the header that defines the current section
+    for (let i = currentLine; i >= 0; i--) {
+      const line = document.lineAt(i);
+      const headerMatch = line.text.match(/^(#{1,6})\s/);
+      if (headerMatch && headerMatch[1]) {
+        return headerMatch[1].length;
+      }
+    }
+    return 1; // Default to top level if no header found
+  }
 
-		const editor = vscode.window.activeTextEditor;
-		if (editor && editor.document.languageId === 'markdown') {
-			this.updateFocusHighlight(editor);
-		}
-	}
+  public toggleFocusMode(): void {
+    const config = vscode.workspace.getConfiguration("markright");
+    const currentMode = config.get("focusMode", "off") as
+      | "off"
+      | "paragraph"
+      | "section";
 
-	dispose() {
-		this.decorationType.dispose();
-		this.disposables.forEach(d => d.dispose());
-	}
+    let newMode: "off" | "paragraph" | "section";
+    switch (currentMode) {
+      case "off":
+        newMode = "paragraph";
+        break;
+      case "paragraph":
+        newMode = "section";
+        break;
+      case "section":
+      default:
+        newMode = "off";
+        break;
+    }
+
+    config.update("focusMode", newMode, vscode.ConfigurationTarget.Global);
+    this.currentFocusMode = newMode;
+
+    vscode.window.showInformationMessage(`Focus mode: ${newMode}`);
+
+    const editor = vscode.window.activeTextEditor;
+    if (editor && editor.document.languageId === "markdown") {
+      this.updateFocusHighlight(editor);
+    }
+  }
+
+  dispose() {
+    this.decorationType.dispose();
+    this.disposables.forEach((d) => d.dispose());
+  }
 }

--- a/src/features/syntaxOverlayProvider.ts
+++ b/src/features/syntaxOverlayProvider.ts
@@ -1,0 +1,520 @@
+import * as vscode from "vscode";
+import katex from "katex";
+import { MarkdownEditorProvider } from "../markdownEditorProvider";
+import { OverlayData, OverlayRange } from "../types/overlay";
+
+interface ParsedOverlay {
+  overlay: OverlayData;
+  endLine: number;
+}
+
+export class SyntaxOverlayProvider implements vscode.Disposable {
+  private editorProvider?: MarkdownEditorProvider;
+  private readonly disposables: vscode.Disposable[] = [];
+  private readonly decorationTypes = new Map<number, vscode.TextEditorDecorationType>();
+  private readonly documentOverlays = new Map<string, OverlayData[]>();
+
+  constructor(private readonly context: vscode.ExtensionContext) {
+    this.initializeDecorations();
+    this.registerListeners();
+  }
+
+  setCustomEditorProvider(provider: MarkdownEditorProvider) {
+    this.editorProvider = provider;
+    this.refreshOpenDocuments();
+  }
+
+  dispose(): void {
+    this.decorationTypes.forEach((decoration) => decoration.dispose());
+    this.decorationTypes.clear();
+
+    this.disposables.forEach((disposable) => disposable.dispose());
+
+    this.documentOverlays.clear();
+  }
+
+  private initializeDecorations() {
+    for (let level = 1; level <= 6; level++) {
+      const decoration = vscode.window.createTextEditorDecorationType({
+        opacity: "0.45",
+        fontWeight: "600",
+      });
+      this.decorationTypes.set(level, decoration);
+    }
+  }
+
+  private registerListeners() {
+    this.disposables.push(
+      vscode.workspace.onDidOpenTextDocument((document) =>
+        this.updateOverlaysForDocument(document)
+      ),
+      vscode.workspace.onDidChangeTextDocument((event) =>
+        this.updateOverlaysForDocument(event.document)
+      ),
+      vscode.workspace.onDidCloseTextDocument((document) =>
+        this.documentOverlays.delete(document.uri.toString())
+      ),
+      vscode.window.onDidChangeActiveTextEditor((editor) => {
+        if (!editor) {
+          return;
+        }
+        const overlays = this.documentOverlays.get(
+          editor.document.uri.toString()
+        );
+        if (overlays) {
+          this.applyDecorations(editor, overlays);
+          this.updateOverlayPosition(editor);
+        }
+      }),
+      vscode.window.onDidChangeTextEditorSelection((event) =>
+        this.handleSelectionChange(event)
+      ),
+      vscode.window.onDidChangeTextEditorVisibleRanges((event) =>
+        this.updateOverlayPosition(event.textEditor)
+      )
+    );
+
+    this.disposables.forEach((disposable) =>
+      this.context.subscriptions.push(disposable)
+    );
+  }
+
+  private refreshOpenDocuments() {
+    vscode.workspace.textDocuments
+      .filter((document) => document.languageId === "markdown")
+      .forEach((document) => this.updateOverlaysForDocument(document));
+  }
+
+  private updateOverlaysForDocument(document: vscode.TextDocument) {
+    if (document.languageId !== "markdown") {
+      return;
+    }
+
+    const overlays = this.parseDocumentForOverlays(document);
+    this.documentOverlays.set(document.uri.toString(), overlays);
+
+    const editor = this.findEditorForDocument(document);
+    if (editor) {
+      this.applyDecorations(editor, overlays);
+    }
+
+    this.sendOverlayUpdates(document, overlays);
+  }
+
+  private parseDocumentForOverlays(document: vscode.TextDocument): OverlayData[] {
+    const overlays: OverlayData[] = [];
+
+    for (let line = 0; line < document.lineCount; line++) {
+      const table = this.tryParseTable(document, line);
+      if (table) {
+        overlays.push(table.overlay);
+        line = table.endLine;
+        continue;
+      }
+
+      const latex = this.tryParseLatex(document, line);
+      if (latex) {
+        overlays.push(latex.overlay);
+        line = latex.endLine;
+        continue;
+      }
+
+      const mermaid = this.tryParseMermaid(document, line);
+      if (mermaid) {
+        overlays.push(mermaid.overlay);
+        line = mermaid.endLine;
+        continue;
+      }
+
+      const heading = this.tryParseHeading(document, line);
+      if (heading) {
+        overlays.push(heading.overlay);
+      }
+    }
+
+    return overlays;
+  }
+
+  private tryParseHeading(
+    document: vscode.TextDocument,
+    lineNumber: number
+  ): ParsedOverlay | undefined {
+    const line = document.lineAt(lineNumber);
+    const match = line.text.match(/^(#{1,6})\s+(.*)$/);
+    if (!match) {
+      return undefined;
+    }
+
+    const levelSource = match[1];
+    const headingText = match[2];
+    if (!levelSource || !headingText) {
+      return undefined;
+    }
+
+    const level = levelSource.length;
+    const rendered = headingText.trim();
+    const range = line.range;
+
+    return {
+      overlay: {
+        type: "heading",
+        level,
+        range: this.toOverlayRange(range),
+        content: line.text,
+        rendered,
+      },
+      endLine: lineNumber,
+    };
+  }
+
+  private tryParseTable(
+    document: vscode.TextDocument,
+    startLine: number
+  ): ParsedOverlay | undefined {
+    if (startLine >= document.lineCount - 1) {
+      return undefined;
+    }
+
+    const headerLine = document.lineAt(startLine).text;
+    const separatorLine = document.lineAt(startLine + 1).text;
+
+    if (!headerLine.includes("|") || !this.isTableSeparator(separatorLine)) {
+      return undefined;
+    }
+
+    const rows: string[] = [headerLine, separatorLine];
+    let endLine = startLine + 1;
+
+    for (let line = startLine + 2; line < document.lineCount; line++) {
+      const text = document.lineAt(line).text;
+      if (!text.includes("|")) {
+        break;
+      }
+      rows.push(text);
+      endLine = line;
+    }
+
+    const range = new vscode.Range(
+      document.lineAt(startLine).range.start,
+      document.lineAt(endLine).range.end
+    );
+
+    return {
+      overlay: {
+        type: "table",
+        range: this.toOverlayRange(range),
+        content: rows.join("\n"),
+        rendered: this.renderTable(rows),
+      },
+      endLine,
+    };
+  }
+
+  private tryParseLatex(
+    document: vscode.TextDocument,
+    startLine: number
+  ): ParsedOverlay | undefined {
+    const line = document.lineAt(startLine).text.trim();
+    if (!line.startsWith("$$")) {
+      return undefined;
+    }
+
+    let content = "";
+    let endLine = startLine;
+    let closed = false;
+
+    if (line === "$$") {
+      for (let index = startLine + 1; index < document.lineCount; index++) {
+        const text = document.lineAt(index).text;
+        const trimmed = text.trim();
+        if (trimmed.endsWith("$$")) {
+          const payload = trimmed === "$$" ? "" : trimmed.slice(0, -2);
+          content = `${content}${content ? "\n" : ""}${payload}`;
+          endLine = index;
+          closed = true;
+          break;
+        }
+
+        content = `${content}${content ? "\n" : ""}${text}`;
+        endLine = index;
+      }
+    } else if (line.endsWith("$$")) {
+      content = line.slice(2, -2).trim();
+      closed = true;
+    } else {
+      content = line.slice(2);
+      for (let index = startLine + 1; index < document.lineCount; index++) {
+        const text = document.lineAt(index).text;
+        const trimmed = text.trim();
+        if (trimmed.endsWith("$$")) {
+          const payload = trimmed === "$$" ? "" : trimmed.slice(0, -2);
+          content = `${content}\n${payload}`;
+          endLine = index;
+          closed = true;
+          break;
+        }
+
+        content = `${content}\n${text}`;
+        endLine = index;
+      }
+    }
+
+    if (!closed) {
+      return undefined;
+    }
+
+    const range = new vscode.Range(
+      document.lineAt(startLine).range.start,
+      document.lineAt(endLine).range.end
+    );
+
+    return {
+      overlay: {
+        type: "latex",
+        range: this.toOverlayRange(range),
+        content: document.getText(range),
+        rendered: this.renderLatexForOverlay(content.trim()),
+      },
+      endLine,
+    };
+  }
+
+  private tryParseMermaid(
+    document: vscode.TextDocument,
+    startLine: number
+  ): ParsedOverlay | undefined {
+    const startText = document.lineAt(startLine).text.trim();
+    const match = startText.match(/^```(\w+)/);
+    if (!match || match[1] !== "mermaid") {
+      return undefined;
+    }
+
+    const codeLines: string[] = [];
+    let endLine = startLine;
+    let closed = false;
+
+    for (let index = startLine + 1; index < document.lineCount; index++) {
+      const text = document.lineAt(index).text;
+      if (text.trim() === "```") {
+        endLine = index;
+        closed = true;
+        break;
+      }
+      codeLines.push(text);
+      endLine = index;
+    }
+
+    if (!closed) {
+      return undefined;
+    }
+
+    const range = new vscode.Range(
+      document.lineAt(startLine).range.start,
+      document.lineAt(endLine).range.end
+    );
+
+    return {
+      overlay: {
+        type: "diagram",
+        range: this.toOverlayRange(range),
+        content: document.getText(range),
+        rendered: codeLines.join("\n"),
+      },
+      endLine,
+    };
+  }
+
+  private isTableSeparator(line: string): boolean {
+    const trimmed = line.trim();
+    if (!trimmed.includes("-")) {
+      return false;
+    }
+
+    return /^\s*\|?(\s*:?[-]+:?\s*\|)+\s*$/.test(trimmed);
+  }
+
+  private renderTable(rows: string[]): string {
+    if (rows.length < 2) {
+      return "";
+    }
+
+    const headerRow = rows[0];
+    const separatorRow = rows[1];
+    if (!headerRow || !separatorRow) {
+      return "";
+    }
+
+    const headerCells = this.splitTableRow(headerRow);
+    const bodyRows = rows.slice(2).map((row) => this.splitTableRow(row));
+
+    const headerHtml = headerCells
+      .map((cell) => `<th>${cell}</th>`)
+      .join("");
+
+    const bodyHtml = bodyRows
+      .map((cells) => `<tr>${cells.map((cell) => `<td>${cell}</td>`).join("")}</tr>`)
+      .join("");
+
+    return `
+      <table class="overlay-table">
+        <thead><tr>${headerHtml}</tr></thead>
+        <tbody>${bodyHtml}</tbody>
+      </table>
+    `;
+  }
+
+  private splitTableRow(row: string | undefined): string[] {
+    if (!row) {
+      return [];
+    }
+    const trimmed = row.trim();
+    const withoutEdges = trimmed
+      .replace(/^\|/, "")
+      .replace(/\|$/, "");
+    return withoutEdges.split("|").map((cell) => cell.trim());
+  }
+
+  private renderLatexForOverlay(latex: string): string {
+    if (!latex) {
+      return "";
+    }
+
+    try {
+      return katex.renderToString(latex, {
+        throwOnError: false,
+        strict: "warn",
+        displayMode: latex.includes("\\n"),
+        maxSize: 50,
+        maxExpand: 100,
+      });
+    } catch (error) {
+      console.warn("KaTeX overlay rendering error", error);
+      return `<span class="latex-error">${latex}</span>`;
+    }
+  }
+
+  private sendOverlayUpdates(
+    document: vscode.TextDocument,
+    overlays: OverlayData[]
+  ) {
+    if (!this.editorProvider) {
+      return;
+    }
+
+    this.editorProvider.updateOverlays(document.uri, overlays);
+
+    const visibleRange = this.getVisibleRangeForDocument(document);
+    this.editorProvider.updateOverlayPosition(document.uri, visibleRange);
+    this.editorProvider.updateOverlayVisibility(document.uri, true);
+  }
+
+  private getVisibleRangeForDocument(
+    document: vscode.TextDocument
+  ): { start: number; end: number } {
+    const editor = this.findEditorForDocument(document);
+    if (editor && editor.visibleRanges.length > 0) {
+      const [firstRange] = editor.visibleRanges;
+      if (firstRange) {
+        return { start: firstRange.start.line, end: firstRange.end.line };
+      }
+    }
+
+    return {
+      start: 0,
+      end: Math.max(document.lineCount - 1, 0),
+    };
+  }
+
+  private updateOverlayPosition(editor: vscode.TextEditor) {
+    if (!this.editorProvider || editor.visibleRanges.length === 0) {
+      return;
+    }
+
+    const [firstRange] = editor.visibleRanges;
+    if (!firstRange) {
+      return;
+    }
+
+    this.editorProvider.updateOverlayPosition(editor.document.uri, {
+      start: firstRange.start.line,
+      end: firstRange.end.line,
+    });
+  }
+
+  private handleSelectionChange(
+    event: vscode.TextEditorSelectionChangeEvent
+  ) {
+    if (!this.editorProvider) {
+      return;
+    }
+
+    const overlays = this.documentOverlays.get(
+      event.textEditor.document.uri.toString()
+    );
+    if (!overlays || overlays.length === 0) {
+      return;
+    }
+
+    const cursorInOverlay = event.selections.some((selection) =>
+      overlays.some((overlay) =>
+        this.toVsRange(overlay.range).contains(selection.active)
+      )
+    );
+
+    this.editorProvider.updateOverlayVisibility(
+      event.textEditor.document.uri,
+      !cursorInOverlay
+    );
+  }
+
+  private applyDecorations(
+    editor: vscode.TextEditor,
+    overlays: OverlayData[]
+  ) {
+    const headingRanges = new Map<number, vscode.Range[]>();
+
+    overlays.forEach((overlay) => {
+      if (overlay.type !== "heading" || !overlay.level) {
+        return;
+      }
+      const ranges = headingRanges.get(overlay.level) ?? [];
+      ranges.push(this.toVsRange(overlay.range));
+      headingRanges.set(overlay.level, ranges);
+    });
+
+    this.decorationTypes.forEach((decoration, level) => {
+      const ranges = headingRanges.get(level) ?? [];
+      editor.setDecorations(decoration, ranges);
+    });
+  }
+
+  private findEditorForDocument(
+    document: vscode.TextDocument
+  ): vscode.TextEditor | undefined {
+    return vscode.window.visibleTextEditors.find(
+      (editor) => editor.document.uri.toString() === document.uri.toString()
+    );
+  }
+
+  private toOverlayRange(range: vscode.Range): OverlayRange {
+    return {
+      start: {
+        line: range.start.line,
+        character: range.start.character,
+      },
+      end: {
+        line: range.end.line,
+        character: range.end.character,
+      },
+    };
+  }
+
+  private toVsRange(range: OverlayRange): vscode.Range {
+    return new vscode.Range(
+      range.start.line,
+      range.start.character,
+      range.end.line,
+      range.end.character
+    );
+  }
+}

--- a/src/markdownEditorProvider.ts
+++ b/src/markdownEditorProvider.ts
@@ -1,165 +1,278 @@
-import * as vscode from 'vscode';
-import * as path from 'path';
-import { MarkdownRenderer } from './markdownRenderer';
-import { WebviewContent } from './webview/webviewContent';
+import * as vscode from "vscode";
+import * as path from "path";
+import { MarkdownRenderer } from "./markdownRenderer";
+import { WebviewContent } from "./webview/webviewContent";
+import { OverlayData } from "./types/overlay";
 
 export class MarkdownEditorProvider implements vscode.CustomTextEditorProvider {
-	public static register(context: vscode.ExtensionContext): vscode.Disposable {
-		const provider = new MarkdownEditorProvider(context.extensionUri);
-		const providerRegistration = vscode.window.registerCustomEditorProvider(MarkdownEditorProvider.viewType, provider);
-		return providerRegistration;
-	}
+  public static register(context: vscode.ExtensionContext): vscode.Disposable {
+    const provider = new MarkdownEditorProvider(context);
+    const providerRegistration = vscode.window.registerCustomEditorProvider(
+      MarkdownEditorProvider.viewType,
+      provider
+    );
+    return providerRegistration;
+  }
 
-	public static readonly viewType = 'markright.markdownEditor';
+  public static readonly viewType = "markright.markdownEditor";
 
-	private readonly renderer: MarkdownRenderer;
-	private readonly webviewContent: WebviewContent;
-	private updateTimeout: NodeJS.Timeout | undefined;
-	private activeWebviewPanels = new Set<vscode.WebviewPanel>();
+  private readonly renderer: MarkdownRenderer;
+  private readonly webviewContent: WebviewContent;
+  private updateTimeout: NodeJS.Timeout | undefined;
+  private activeWebviewPanels = new Set<vscode.WebviewPanel>();
+  private panelToDocument = new Map<vscode.WebviewPanel, vscode.TextDocument>();
+  private documentToPanels = new Map<string, Set<vscode.WebviewPanel>>();
 
-	constructor(
-		private readonly extensionUri: vscode.Uri
-	) {
-		this.renderer = new MarkdownRenderer();
-		this.webviewContent = new WebviewContent(extensionUri);
-	}
+  constructor(private readonly context: vscode.ExtensionContext) {
+    this.renderer = new MarkdownRenderer();
+    this.webviewContent = new WebviewContent(context.extensionUri);
+  }
 
-	public async resolveCustomTextEditor(
-		document: vscode.TextDocument,
-		webviewPanel: vscode.WebviewPanel,
-		_token: vscode.CancellationToken
-	): Promise<void> {
-		webviewPanel.webview.options = {
-			enableScripts: true,
-		};
-		webviewPanel.webview.html = await this.webviewContent.getHtmlForWebview(webviewPanel.webview);
-		
-		// Track this webview panel
-		this.activeWebviewPanels.add(webviewPanel);
+  public async resolveCustomTextEditor(
+    document: vscode.TextDocument,
+    webviewPanel: vscode.WebviewPanel,
+    _token: vscode.CancellationToken
+  ): Promise<void> {
+    webviewPanel.webview.options = {
+      enableScripts: true,
+    };
+    webviewPanel.webview.html = await this.webviewContent.getHtmlForWebview(
+      webviewPanel.webview
+    );
 
-		const updateWebview = () => {
-			webviewPanel.webview.postMessage({
-				type: 'update',
-				text: document.getText(),
-			});
-		};
+    this.activeWebviewPanels.add(webviewPanel);
+    this.trackPanelForDocument(webviewPanel, document);
 
-		// Debounced update function to prevent excessive updates
-		const debouncedUpdate = () => {
-			if (this.updateTimeout) {
-				clearTimeout(this.updateTimeout);
-			}
-			this.updateTimeout = setTimeout(updateWebview, 300);
-		};
+    const updateWebview = () => {
+      const text = document.getText();
+      const html = this.renderer.renderToHtml(text, {
+        focusMode: this.getCurrentFocusMode(),
+      });
 
-		// Hook up event handlers so that we can synchronize the webview with the text document.
-		const changeDocumentSubscription = vscode.workspace.onDidChangeTextDocument(e => {
-			if (e.document.uri.toString() === document.uri.toString()) {
-				debouncedUpdate();
-			}
-		});
+      webviewPanel.webview.postMessage({
+        type: "update",
+        text,
+        html,
+      });
+    };
 
-		// Make sure we get rid of the listener when our editor is closed.
-		webviewPanel.onDidDispose(() => {
-			changeDocumentSubscription.dispose();
-			if (this.updateTimeout) {
-				clearTimeout(this.updateTimeout);
-				this.updateTimeout = undefined;
-			}
-			this.activeWebviewPanels.delete(webviewPanel);
-		});
+    // Debounced update function to prevent excessive updates
+    const debouncedUpdate = () => {
+      if (this.updateTimeout) {
+        clearTimeout(this.updateTimeout);
+      }
+      this.updateTimeout = setTimeout(updateWebview, 300);
+    };
 
-		// Receive message from the webview.
-		webviewPanel.webview.onDidReceiveMessage(e => {
-			switch (e.type) {
-				case 'edit':
-					this.updateTextDocument(document, e.text);
-					return;
-				case 'cursor':
-					this.updateCursor(e.line, e.character);
-					return;
-				case 'insertWikiLink':
-					this.insertWikiLink(document, e.position, e.text);
-					return;
-				case 'requestContent':
-					updateWebview();
-					return;
-				case 'openWikiLink':
-					this.openWikiLink(e.link);
-					return;
-			}
-		});
+    // Hook up event handlers so that we can synchronize the webview with the text document.
+    const changeDocumentSubscription = vscode.workspace.onDidChangeTextDocument(
+      (e) => {
+        if (e.document.uri.toString() === document.uri.toString()) {
+          debouncedUpdate();
+        }
+      }
+    );
 
-		// Send initial content
-		updateWebview();
-	}
+    // Make sure we get rid of the listener when our editor is closed.
+    webviewPanel.onDidDispose(() => {
+      changeDocumentSubscription.dispose();
+      if (this.updateTimeout) {
+        clearTimeout(this.updateTimeout);
+        this.updateTimeout = undefined;
+      }
+      this.activeWebviewPanels.delete(webviewPanel);
+      this.releasePanel(webviewPanel);
+    });
 
-	private updateTextDocument(document: vscode.TextDocument, text: string) {
-		const edit = new vscode.WorkspaceEdit();
-		edit.replace(
-			document.uri,
-			new vscode.Range(0, 0, document.lineCount, 0),
-			text
-		);
-		return vscode.workspace.applyEdit(edit);
-	}
+    // Receive message from the webview.
+    webviewPanel.webview.onDidReceiveMessage((e) => {
+      switch (e.type) {
+        case "edit":
+          this.updateTextDocument(document, e.text);
+          return;
+        case "cursor":
+          this.updateCursor(e.line, e.character);
+          return;
+        case "insertWikiLink":
+          this.insertWikiLink(document, e.position, e.text);
+          return;
+        case "requestContent":
+          updateWebview();
+          return;
+        case "openWikiLink":
+          this.openWikiLink(e.link);
+          return;
+      }
+    });
 
-	private updateCursor(line: number, character: number) {
-		const editor = vscode.window.activeTextEditor;
-		if (editor) {
-			const position = new vscode.Position(line, character);
-			editor.selection = new vscode.Selection(position, position);
-			editor.revealRange(new vscode.Range(position, position));
-		}
-	}
+    // Send initial content
+    updateWebview();
+  }
 
-	private insertWikiLink(document: vscode.TextDocument, position: { line: number; character: number }, linkText: string) {
-		const edit = new vscode.WorkspaceEdit();
-		const pos = new vscode.Position(position.line, position.character);
-		edit.insert(document.uri, pos, `[[${linkText}]]`);
-		return vscode.workspace.applyEdit(edit);
-	}
+  private updateTextDocument(document: vscode.TextDocument, text: string) {
+    const edit = new vscode.WorkspaceEdit();
+    edit.replace(
+      document.uri,
+      new vscode.Range(0, 0, document.lineCount, 0),
+      text
+    );
+    return vscode.workspace.applyEdit(edit);
+  }
 
-	public togglePreview() {
-		// Toggle preview mode for all active webview panels
-		this.activeWebviewPanels.forEach(panel => {
-			panel.webview.postMessage({
-				type: 'togglePreview'
-			});
-		});
-		
-		if (this.activeWebviewPanels.size > 0) {
-			vscode.window.showInformationMessage('Preview mode toggled');
-		} else {
-			vscode.window.showInformationMessage('No active MarkRight editors to toggle preview');
-		}
-	}
+  private updateCursor(line: number, character: number) {
+    const editor = vscode.window.activeTextEditor;
+    if (editor) {
+      const position = new vscode.Position(line, character);
+      editor.selection = new vscode.Selection(position, position);
+      editor.revealRange(new vscode.Range(position, position));
+    }
+  }
 
-	private async openWikiLink(linkText: string) {
-		const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
-		if (!workspaceFolder) {
-			vscode.window.showErrorMessage('No workspace open');
-			return;
-		}
+  private insertWikiLink(
+    document: vscode.TextDocument,
+    position: { line: number; character: number },
+    linkText: string
+  ) {
+    const edit = new vscode.WorkspaceEdit();
+    const pos = new vscode.Position(position.line, position.character);
+    edit.insert(document.uri, pos, `[[${linkText}]]`);
+    return vscode.workspace.applyEdit(edit);
+  }
 
-		// Try to find the file
-		const pattern = new vscode.RelativePattern(workspaceFolder, `**/${linkText}.md`);
-		const files = await vscode.workspace.findFiles(pattern);
-		
-		if (files.length > 0) {
-			// Open the existing file
-			const document = await vscode.workspace.openTextDocument(files[0]);
-			await vscode.window.showTextDocument(document);
-		} else {
-			// Create a new file
-			const newFileUri = vscode.Uri.joinPath(workspaceFolder.uri, `${linkText}.md`);
-			const edit = new vscode.WorkspaceEdit();
-			edit.createFile(newFileUri, { ignoreIfExists: true });
-			edit.insert(newFileUri, new vscode.Position(0, 0), `# ${linkText}\n\n`);
-			
-			await vscode.workspace.applyEdit(edit);
-			const document = await vscode.workspace.openTextDocument(newFileUri);
-			await vscode.window.showTextDocument(document);
-		}
-	}
+  public togglePreview() {
+    // Toggle preview mode for all active webview panels
+    this.activeWebviewPanels.forEach((panel) => {
+      panel.webview.postMessage({
+        type: "togglePreview",
+      });
+    });
+
+    if (this.activeWebviewPanels.size > 0) {
+      vscode.window.showInformationMessage("Preview mode toggled");
+    } else {
+      vscode.window.showInformationMessage(
+        "No active MarkRight editors to toggle preview"
+      );
+    }
+  }
+
+  public updateOverlays(documentUri: vscode.Uri, overlays: OverlayData[]) {
+    this.forEachPanel(documentUri, (panel) => {
+      panel.webview.postMessage({
+        type: "updateOverlays",
+        overlays,
+      });
+    });
+  }
+
+  public updateOverlayPosition(
+    documentUri: vscode.Uri,
+    visibleRange: { start: number; end: number }
+  ) {
+    this.forEachPanel(documentUri, (panel) => {
+      panel.webview.postMessage({
+        type: "positionUpdate",
+        visibleRange,
+      });
+    });
+  }
+
+  public updateOverlayVisibility(documentUri: vscode.Uri, visible: boolean) {
+    this.forEachPanel(documentUri, (panel) => {
+      panel.webview.postMessage({
+        type: "setVisibility",
+        visible,
+      });
+    });
+  }
+
+  private async openWikiLink(linkText: string) {
+    const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+    if (!workspaceFolder) {
+      vscode.window.showErrorMessage("No workspace open");
+      return;
+    }
+
+    // Try to find the file
+    const pattern = new vscode.RelativePattern(
+      workspaceFolder,
+      `**/${linkText}.md`
+    );
+    const files = await vscode.workspace.findFiles(pattern);
+
+    if (files.length > 0 && files[0]) {
+      // Open the existing file
+      const document = await vscode.workspace.openTextDocument(files[0]);
+      await vscode.window.showTextDocument(document);
+    } else {
+      // Create a new file
+      const newFileUri = vscode.Uri.joinPath(
+        workspaceFolder.uri,
+        `${linkText}.md`
+      );
+      const edit = new vscode.WorkspaceEdit();
+      edit.createFile(newFileUri, { ignoreIfExists: true });
+      edit.insert(newFileUri, new vscode.Position(0, 0), `# ${linkText}\n\n`);
+
+      await vscode.workspace.applyEdit(edit);
+      const document = await vscode.workspace.openTextDocument(newFileUri);
+      await vscode.window.showTextDocument(document);
+    }
+  }
+
+  private getCurrentFocusMode(): "off" | "paragraph" | "section" {
+    const config = vscode.workspace.getConfiguration("markright");
+    return (
+      config.get("focusMode", "off") as "off" | "paragraph" | "section"
+    );
+  }
+
+  private trackPanelForDocument(
+    panel: vscode.WebviewPanel,
+    document: vscode.TextDocument
+  ) {
+    this.panelToDocument.set(panel, document);
+    const key = document.uri.toString();
+    let panels = this.documentToPanels.get(key);
+    if (!panels) {
+      panels = new Set();
+      this.documentToPanels.set(key, panels);
+    }
+    panels.add(panel);
+  }
+
+  private releasePanel(panel: vscode.WebviewPanel) {
+    const document = this.panelToDocument.get(panel);
+    if (!document) {
+      return;
+    }
+
+    this.panelToDocument.delete(panel);
+    const key = document.uri.toString();
+    const panels = this.documentToPanels.get(key);
+    if (!panels) {
+      return;
+    }
+
+    panels.delete(panel);
+    if (panels.size === 0) {
+      this.documentToPanels.delete(key);
+    }
+  }
+
+  private forEachPanel(
+    documentUri: vscode.Uri,
+    callback: (panel: vscode.WebviewPanel) => void
+  ) {
+    const panels = this.documentToPanels.get(documentUri.toString());
+    if (!panels) {
+      return;
+    }
+
+    panels.forEach((panel) => {
+      if (panel) {
+        callback(panel);
+      }
+    });
+  }
 }

--- a/src/types/overlay.ts
+++ b/src/types/overlay.ts
@@ -1,0 +1,20 @@
+export type OverlayKind = "heading" | "table" | "latex" | "diagram";
+
+export interface OverlayRange {
+  start: {
+    line: number;
+    character: number;
+  };
+  end: {
+    line: number;
+    character: number;
+  };
+}
+
+export interface OverlayData {
+  type: OverlayKind;
+  level?: number;
+  range: OverlayRange;
+  content: string;
+  rendered: string;
+}

--- a/src/webview/webviewContent.ts
+++ b/src/webview/webviewContent.ts
@@ -1,19 +1,40 @@
-import * as vscode from 'vscode';
-import * as path from 'path';
+import * as vscode from "vscode";
+import * as path from "path";
 
 export class WebviewContent {
-	constructor(private readonly extensionUri: vscode.Uri) {}
+  constructor(private readonly extensionUri: vscode.Uri) {}
 
-	public async getHtmlForWebview(webview: vscode.Webview): Promise<string> {
-		// Get the local path to main script run in the webview, then convert it to a uri we can use in the webview.
-		const scriptUri = webview.asWebviewUri(vscode.Uri.joinPath(this.extensionUri, 'media', 'editor.js'));
-		const styleMainUri = webview.asWebviewUri(vscode.Uri.joinPath(this.extensionUri, 'media', 'editor.css'));
-		const katexStyleUri = webview.asWebviewUri(vscode.Uri.joinPath(this.extensionUri, 'node_modules', 'katex', 'dist', 'katex.min.css'));
+  public async getHtmlForWebview(webview: vscode.Webview): Promise<string> {
+    // Get the local path to main script run in the webview, then convert it to a uri we can use in the webview.
+    const scriptUri = webview.asWebviewUri(
+      vscode.Uri.joinPath(this.extensionUri, "media", "editor.js")
+    );
+    const styleMainUri = webview.asWebviewUri(
+      vscode.Uri.joinPath(this.extensionUri, "media", "editor.css")
+    );
+    const katexStyleUri = webview.asWebviewUri(
+      vscode.Uri.joinPath(
+        this.extensionUri,
+        "node_modules",
+        "katex",
+        "dist",
+        "katex.min.css"
+      )
+    );
+    const mermaidScriptUri = webview.asWebviewUri(
+      vscode.Uri.joinPath(
+        this.extensionUri,
+        "node_modules",
+        "mermaid",
+        "dist",
+        "mermaid.min.js"
+      )
+    );
 
-		// Use a nonce to only allow specific scripts to be run
-		const nonce = this.getNonce();
+    // Use a nonce to only allow specific scripts to be run
+    const nonce = this.getNonce();
 
-		return `<!DOCTYPE html>
+    return `<!DOCTYPE html>
 			<html lang="en">
 			<head>
 				<meta charset="UTF-8">
@@ -22,6 +43,68 @@ export class WebviewContent {
 				<link href="${katexStyleUri}" rel="stylesheet">
 				<link href="${styleMainUri}" rel="stylesheet">
 				<title>MarkRight Editor</title>
+				<style>
+					.editor-pane {
+						position: relative;
+					}
+					#markdown-editor {
+						position: relative;
+						z-index: 1;
+					}
+					.overlay-container {
+						position: absolute;
+						top: 0;
+						left: 0;
+						width: 100%;
+						height: 100%;
+						pointer-events: none;
+						z-index: 2;
+					}
+					.floating-overlay {
+						position: absolute;
+						background: var(--vscode-editor-background);
+						border-radius: 4px;
+						padding: 2px 6px;
+						opacity: 0.96;
+						pointer-events: none;
+						color: var(--vscode-editor-foreground);
+						box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+					}
+					.floating-overlay.hidden {
+						opacity: 0;
+					}
+					.floating-overlay.heading {
+						white-space: nowrap;
+						background: transparent;
+						box-shadow: none;
+					}
+					.overlay-table {
+						border-collapse: collapse;
+						width: max-content;
+						max-width: 520px;
+						background: var(--vscode-editor-background);
+						border: 1px solid var(--vscode-panel-border);
+					}
+					.overlay-table th,
+					.overlay-table td {
+						border: 1px solid var(--vscode-panel-border);
+						padding: 4px 8px;
+						background: var(--vscode-editor-background);
+						color: var(--vscode-editor-foreground);
+					}
+					.latex {
+						background: var(--vscode-editor-background);
+						padding: 8px;
+						border: 1px solid var(--vscode-panel-border);
+						border-radius: 4px;
+					}
+					.mermaid {
+						background: var(--vscode-editor-background);
+						padding: 8px;
+						border: 1px solid var(--vscode-panel-border);
+						border-radius: 4px;
+					}
+				</style>
 			</head>
 			<body>
 				<div class="editor-container">
@@ -37,6 +120,7 @@ export class WebviewContent {
 					<div class="editor-content">
 						<div class="editor-pane" id="editor-pane">
 							<textarea id="markdown-editor" placeholder="Start writing your markdown here..."></textarea>
+							<div class="overlay-container" id="overlay-container"></div>
 						</div>
 						
 						<div class="preview-pane" id="preview-pane">
@@ -45,17 +129,19 @@ export class WebviewContent {
 					</div>
 				</div>
 
+				<script nonce="${nonce}" src="${mermaidScriptUri}"></script>
 				<script nonce="${nonce}" src="${scriptUri}"></script>
 			</body>
 			</html>`;
-	}
+  }
 
-	private getNonce(): string {
-		let text = '';
-		const possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
-		for (let i = 0; i < 32; i++) {
-			text += possible.charAt(Math.floor(Math.random() * possible.length));
-		}
-		return text;
-	}
+  private getNonce(): string {
+    let text = "";
+    const possible =
+      "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+    for (let i = 0; i < 32; i++) {
+      text += possible.charAt(Math.floor(Math.random() * possible.length));
+    }
+    return text;
+  }
 }

--- a/test.md
+++ b/test.md
@@ -1,0 +1,44 @@
+# Test Heading Level 1
+
+This is a test of the heading overlay system.
+
+## Test Heading Level 2
+
+Here we have a second level heading.
+
+### Test Heading Level 3
+
+And a third level heading with some content.
+
+#### Test Heading Level 4
+
+Fourth level heading.
+
+##### Test Heading Level 5
+
+Fifth level heading.
+
+###### Test Heading Level 6
+
+Sixth level heading.
+
+## Table Test
+
+| Header 1 | Header 2 | Header 3 |
+| -------- | -------- | -------- |
+| Cell 1   | Cell 2   | Cell 3   |
+| Cell 4   | Cell 5   | Cell 6   |
+
+## LaTeX Test
+
+$$E = mc^2$$
+
+## Mermaid Diagram Test
+
+```mermaid
+graph TD
+    A[Start] --> B{Is it working?}
+    B -->|Yes| C[Great!]
+    B -->|No| D[Debug]
+    D --> B
+```

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,22 +1,26 @@
 {
   "compilerOptions": {
     "module": "commonjs",
-    "target": "ES2020",
+    "target": "ES2022",
     "outDir": "out",
-    "lib": [
-      "ES2020"
-    ],
+    "lib": ["ES2022"],
     "sourceMap": true,
     "rootDir": "src",
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "moduleResolution": "node",
+    "allowSyntheticDefaultImports": true,
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "types": ["vscode", "node"]
   },
-  "exclude": [
-    "node_modules",
-    ".vscode-test",
-    "src/test"
-  ]
+  "exclude": ["node_modules", ".vscode-test", "src/test", "media"]
 }


### PR DESCRIPTION
## Summary
- add overlay data models shared between extension and webview
- stream parsed heading/table/LaTeX/Mermaid overlays into the custom editor
- render overlays inside the webview and keep preview in sync

## Testing
- npm run compile